### PR TITLE
Fix the setOption test

### DIFF
--- a/test/thinky.js
+++ b/test/thinky.js
@@ -147,7 +147,7 @@ describe('Thinky', function(){
             Cat = thinky.createModel('Cat', { id: String, name: String });
             catou = new Cat({name: 'Catou'});
             catou.save(function(error, result) {
-                should.equal(error.name, 'RqlRuntimeError');
+                should.equal(error.name, 'RqlDriverError');
                 thinky.setOption('db', 'test');
                 done();
             })


### PR DESCRIPTION
Was getting this error when running the tests:

```

C:\dev\WebStorm\thinky>npm test

> thinky@0.2.15 test C:\dev\WebStorm\thinky
> mocha

<...>

  153 passing (3s)
  1 failing

  1) Thinky setOption should be able to change the db:

      actual expected

      RqlRuntimeErrorRqlDriverError

  AssertionError: "RqlDriverError" == "RqlRuntimeError"
      at options.poolMax (C:\dev\WebStorm\thinky\test\thinky.js:150:24)
      at Document.createCallback.fn (C:\dev\WebStorm\thinky\lib\document.js:116:65)
      at Model._execute (C:\dev\WebStorm\thinky\lib\model.js:342:20)
      at exports.Pool.diff (C:\dev\WebStorm\thinky\node_modules\generic-pool\lib\generic-pool.js:271:11)
      at Thinky.createPool.pool.gpool.Pool.create (C:\dev\WebStorm\thinky\lib\index.js:67:24)
      at TcpConnection.errCallback (C:\dev\WebStorm\thinky\node_modules\rethinkdb\net.js:122:16)
      at TcpConnection.g (events.js:192:14)
      at TcpConnection.EventEmitter.emit (events.js:96:17)
      at Socket.TcpConnection.rawSocket.on._this.open (C:\dev\WebStorm\thinky\node_modules\rethinkdb\net.js:429:25)
      at Socket.EventEmitter.emit (events.js:126:20)
      at Socket._destroy.self.errorEmitted (net.js:329:14)
      at process.startup.processNextTick.process._tickCallback (node.js:244:9)



npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0

```
