### PR TITLE
Fix TypeError when trying to get() a non-existing document by ID

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -423,9 +423,9 @@ Model.prototype.callbacks = {
             if (error) {
                 callback(error, null);
             }
-			else if (!result) {
-				callback(null, null);
-			}
+            else if (!result) {
+                callback(null, null);
+            }
             else if (typeof result.toArray === 'function') {
                 result.toArray( function(error, results) {
                     if (error) {

--- a/test/model.js
+++ b/test/model.js
@@ -475,13 +475,13 @@ describe('Model', function(){
                 done();
             })
         });
-		it('should return null if document does not exist', function(done){
-			Cat.get('FAKE_ID', function(error, result){
-				should.not.exist(error);
-				should.not.exist(result);
-				done();
-			});
-		});
+        it('should return null if document does not exist', function(done){
+            Cat.get('FAKE_ID', function(error, result){
+                should.not.exist(error);
+                should.not.exist(result);
+                done();
+            });
+        });
     });
     describe('getAll', function() {
         it('should retrieve some documents in the database -- single values', function(done){


### PR DESCRIPTION
Fixes the TypeError that occurs in Model.callbacks.any() when trying to get() any non-exisitng document by ID.

I wasn't entirely sure if this was the best way to fix it, but here's my attempt. Either way, there's an issue. IMO, there should either be an error or we should get a null document. 

The error stacktrace is posted below. A test case to replicate the issue is also in the commit, in case you want to try a different fix.

```

> thinky@0.2.15 test C:\dev\WebStorm\thinky
> mocha

   <...>

  154 passing (3s)
  1 failing

  1) Model get should return null if document does not exist:
     Uncaught TypeError: Cannot read property 'toArray' of null
      at Model.callbacks.any (C:\dev\WebStorm\thinky\lib\model.js:426:35)
      at Query.run (C:\dev\WebStorm\thinky\lib\query.js:351:13)
      at Object.Connection._processResponse.pb.ResponseTypeSwitch.SUCCESS_ATOM (C:\dev\WebStorm\thinky\node_modules\rethinkdb\net.js:230:13)
      at Object.module.exports.ResponseTypeSwitch (C:\dev\WebStorm\thinky\node_modules\rethinkdb\protobuf.js:61:29)
      at TcpConnection.Connection._processResponse (C:\dev\WebStorm\thinky\node_modules\rethinkdb\net.js:212:19)
      at TcpConnection.Connection._data (C:\dev\WebStorm\thinky\node_modules\rethinkdb\net.js:145:12)
      at Socket.TcpConnection.rawSocket.once.handshake_callback (C:\dev\WebStorm\thinky\node_modules\rethinkdb\net.js:413:30)
      at Socket.EventEmitter.emit (events.js:96:17)
      at TCP.onread (net.js:397:14)

```
