### PR TITLE
allow .define() to set an object descriptor for more versatility

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -64,7 +64,7 @@ function Document(model, options) {
 
     for(var key in model._methods) {
         if (this[key] === undefined) {
-            this[key] = model._methods[key];
+            Object.defineProperty(this, key, model._methods[key]);
         }
         else {
             console.log(this[key]);
@@ -177,7 +177,7 @@ Document.prototype.__generateDefault = function(doc, schema, options, originalDo
 
 /*
  * Validate the schema
- * 
+ *
  * options = {getJoin: true}
  */
 Document.prototype.validate = function(options) {
@@ -272,7 +272,7 @@ Document.prototype.__validate = function(doc, schema, prefix, options, originalD
     // An element in an array can never be undefined because RethinkDB doesn't support such type
     */
     var fieldChecked = false;
-    
+
     // Set the local settings
     if (util.isPlainObject(schema) && (schema._type !== undefined) && (util.isPlainObject(schema.options))) {
         localOptions.enforce_missing = (schema.options.enforce_missing != null) ? schema.options.enforce_missing : localOptions.enforce_missing;
@@ -575,7 +575,7 @@ Document.prototype._save = function(modelToSave, saveAll, savedModel) {
                                 }
                                 newLink[constructor.getTableName()+"_"+model._joins[key].leftKey] = self[model._joins[key].leftKey];
                                 newLink[model._joins[key].model.getTableName()+"_"+model._joins[key].rightKey] = link;
-                                
+
                                 (function(key, link) {
                                     promisesLink.push(new Promise(function(resolve, reject) {
                                         r.table(self._getModel()._joins[key].link).insert(newLink, {upsert: true, returnVals: true}).run().then(function(result) {
@@ -679,7 +679,7 @@ Document.prototype._save = function(modelToSave, saveAll, savedModel) {
                         }
                     }
                     self.__proto__._hasMany[key] = [];
-                    
+
                     for(var i=0; i<self[key].length; i++) {
                         self[key][i][model._joins[key].rightKey] = self[model._joins[key].leftKey];
                         (function(key, i) {
@@ -766,7 +766,7 @@ Document.prototype._save = function(modelToSave, saveAll, savedModel) {
                     }
                 }
             }
- 
+
             if (self.__proto__._saved === false) {
                 var savedDocCb = function(result) {
                     try{ // Validate the doc, replace it, and tag it as saved
@@ -1084,7 +1084,7 @@ Document.prototype._delete = function(modelToDelete, deleteAll, deletedModel, de
                     if ((self[key][i] instanceof Document) && (self[key][i].isSaved() === true)) {
                         pks.push(self[key][i][joins[key].model._getModel()._pk]);
                         docsToDelete.push(self[key][i]);
-                        // We are going to do a range delete, but we still have to recurse 
+                        // We are going to do a range delete, but we still have to recurse
                         promises.push(self[key][i]._delete(modelToDelete[key], deleteAll, deletedModel, false, false))
 
                         if (self.getModel()._getModel()._pk === joins[key].leftKey) {
@@ -1201,7 +1201,7 @@ Document.prototype._delete = function(modelToDelete, deleteAll, deletedModel, de
         Promise.all(promises).then(function() {
             resolve(self);
         }).error(function(error) {
-            reject(error) 
+            reject(error)
         });
     })
 }

--- a/lib/model.js
+++ b/lib/model.js
@@ -441,7 +441,7 @@ Model.prototype.belongsTo = function(joinedModel, fieldDoc, leftKey, rightKey, o
                 })
             )
         )
-        
+
         if (self._getModel()._tableCreated === true) {
             query.run().then(function(result) {
                 self._indexWasCreated('local');
@@ -818,7 +818,18 @@ Model.prototype.then = function() {
 
 
 Model.prototype.define = function(key, fn) {
-    this._methods[key] = fn;
+
+    var descriptor;
+
+    if (fnOrDescriptor instanceof Function) {
+        descriptor = {
+            value: fnOrDescriptor
+        };
+    } else {
+        descriptor = fnOrDescriptor;
+    }
+
+    this._methods[key] = descriptor;
 }
 
 
@@ -840,7 +851,7 @@ Model.prototype._parse = function(data) {
                 catch(error) {
                     var newError = new Error();
                     newError.message = "The results could not be converted to instances of `"+self.getTableName()+"`\nDetailed error: "+error.message
-                
+
                     return reject(newError);
                 }
             }).error(reject)


### PR DESCRIPTION
A follow-up to my earlier suggestion.

Using an optional descriptor rather than a simple function should allow for more versatility in creating instance methods.
