### PR TITLE
The schema var is undefined on deep child objects

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -728,7 +728,7 @@ Document.prototype.__makeSavableCopy = function(doc, schema, model) {
     // We pass it on the first level
 
     var result, key, keys, nextSchema, copyFlag;
-    if (util.isPlainObject(doc) && (doc instanceof Buffer === false)) {
+    if (util.isPlainObject(doc) && (doc instanceof Buffer === false) && schema !== undefined) {
         keys = Object.keys(doc);
         result = {};
         for(var i=0; i<keys.length; i++) {


### PR DESCRIPTION
I created an `event` table where I only defined part of the schema e.g. timestamp, type, etc.

Any child object that wasn't defined would throw an ambiguous error like `[TypeError: Cannot read property 'ip' of undefined]` which I eventually traced down to this recursive function.
