### PR TITLE
Added enforce_extra = 'omit' option

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -682,7 +682,7 @@ Document.prototype.__validate = function(doc, schema, prefix, options, originalD
     if (localOptions.enforce_extra && util.isPlainObject(schema) && (schema._type === undefined)) {
         for(var key in doc) {
             if (((doc._getModel == null) || (doc._getModel()._joins.hasOwnProperty(key) === false)) && (doc.hasOwnProperty(key)) && (schema.hasOwnProperty(key) === false)) {
-                if (localOptions.enforce_extra === 'omit') {
+                if (localOptions.enforce_extra === 'remove') {
                     delete doc[key]
                 }
                 else {

--- a/test/schema.js
+++ b/test/schema.js
@@ -1854,14 +1854,14 @@ describe('validate', function(){
             return error.message === "Extra field `buzz` in [foo] not allowed.";
         });
     });
-    it('Extra field - omit', function(){
+    it('Extra field - enforce_extra:"remove"', function(){
         var name = util.s8();
         var str = util.s8();
 
         var Model = thinky.createModel(name, {
             id: String,
             foo: {fizz: String},
-        }, {init: false, enforce_extra: 'omit'})
+        }, {init: false, enforce_extra: 'remove'})
 
         doc = new Model({
             id: str,


### PR DESCRIPTION
Proposal for solving #67. When `enforce_extra` is set to `omit`, any properties not defined in the schema will be removed during validation. Example:

``` js
var Model = thinky.createModel('models', {
  id: String,
  foo: { bar: String },
}, { enforce_extra: 'omit' });

var doc = new Model({
  id: 'UUID',
  foo: { bar: 'Hello', buzz: 'OMIT' },
  fizz: 'OMIT'
});

doc.validate();
//  doc ==  { id: 'UUID', foo: { bar: 'Hello' } }
```
