### PR TITLE
Optimize more Query.filter() cases

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -923,24 +923,19 @@ for(var key in Term) {
                         var query = new Query(this);
                         if ((arguments.length === 1)
                             && (util.isPlainObject(arguments[0]))) {
-                            var index = null,
-                                filter = arguments[0],
+                            var filter = arguments[0],
                                 indices = this._getModel()._indexes;
 
-                            for (var key in filter) {
-                                if (indices[key]) {
-                                    index = { name: key, value: filter[key] };
-                                    delete filter[key];
+                            for (var index in filter) {
+                                if (indices[index]) {
+                                    query = query.getAll(filter[index], {index: index});
+                                    delete filter[index];
                                     break;
                                 }
                             }
-
-                            if (index !== null) {
-                                query = query.getAll(index.value, {index: index.name});
-                            }
                         }
 
-                        query = query.filter.apply(query, arguments);
+                        query = query[key].apply(query, arguments);
                         return query;
                     }
                     break;


### PR DESCRIPTION
Instead of only attempting to optimize the query when a single property is passed, this implementation iterates over all the properties and does an indexed `.getAll()` on the first index available.
