### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ post.saveAll().then(function(result) {
 Retrieve the post with its author.
 
 ```js
-Post.get("0e4a6f6f-cc0c-4aa5-951a-fcfc480dd05a").getJoin().then(function(result) {
+Post.get("0e4a6f6f-cc0c-4aa5-951a-fcfc480dd05a").getJoin().run().then(function(result) {
     /*
     result = {
         id: "0e4a6f6f-cc0c-4aa5-951a-fcfc480dd05a",


### PR DESCRIPTION
Added .run() because getJoins() returns a query object not a promise to chain. Otherwise below error is returned 

```
Error: The method `then` is not defined on Query. Did you forgot `.run()` or `.execute()`?
    at Query.then (/Users/chan/Development/Workspaces/Node-Workspace/sequel-io/node_modules/thinky/lib/query.js:291:11)
```
