### PR TITLE
Fix purge on models referenced by a hasMany join

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1554,8 +1554,14 @@ Document.prototype.purge = function(callback) {
   // Clean parent for hasMany
   util.loopKeys(self.__proto__._parents._hasMany, function(hasMany, key) {
     for(var i=0; i<hasMany[key].length; i++) {
-      var parentDoc = hasMany[key][i].doc; // A doc that belongs to otherDoc (aka this)
-      delete parentDoc[hasMany[key][i].key] // Delete reference to otherDoc (aka this)
+      var parentDoc = hasMany[key][i].doc;
+      var field = hasMany[key][i].key;
+      for(var j=0; j<parentDoc[field].length; j++) {
+        if (parentDoc[field][j] === this) {
+          parentDoc[field].splice(j, 1);
+          break;
+        }
+      }
     }
   });
 
@@ -1565,7 +1571,7 @@ Document.prototype.purge = function(callback) {
     for(var i=0; i<belongsLinks[key].length; i++) {
       var parentDoc = belongsLinks[key][i].doc;
       var field = belongsLinks[key][i].key;
-      for(var j =0; j< parentDoc[field].length; j++) {
+      for(var j=0; j<parentDoc[field].length; j++) {
         if (parentDoc[field][j] === this) {
           parentDoc[field].splice(j, 1);
           break;


### PR DESCRIPTION
Seems to have been broken by the hook refactor in aa748ff4e00101859847c23e4ccfa74b4e60ddbe.