### PR TITLE
Add .id(), .optional() and .required() as aliases

### DIFF
--- a/lib/type/array.js
+++ b/lib/type/array.js
@@ -27,6 +27,21 @@ TypeArray.prototype.required = function() {
 }
 
 
+TypeArray.prototype.noTypeCheck = function() {
+  return this.options({enforce_type: 'none'});
+}
+
+
+TypeArray.prototype.looseTypeCheck = function() {
+  return this.options({enforce_type: 'loose'});
+}
+
+
+TypeArray.prototype.strictTypeCheck = function() {
+  return this.options({enforce_type: 'strict'});
+}
+
+
 TypeArray.prototype.min = function(min) {
   if (min < 0) {
     throw new Error("The value for `min` must be a positive integer");

--- a/lib/type/array.js
+++ b/lib/type/array.js
@@ -27,18 +27,13 @@ TypeArray.prototype.required = function() {
 }
 
 
-TypeArray.prototype.noTypeCheck = function() {
-  return this.options({enforce_type: 'none'});
-}
-
-
-TypeArray.prototype.looseTypeCheck = function() {
-  return this.options({enforce_type: 'loose'});
-}
-
-
-TypeArray.prototype.strictTypeCheck = function() {
-  return this.options({enforce_type: 'strict'});
+TypeArray.prototype.checkType = function(isChecked, allowNull) {
+  allowNull = typeof allowNull !== 'undefined' ? allowNull : true;
+  var value = 'none';
+  if (isChecked) {
+    value = allowNull ? 'loose' : 'strict';
+  }
+  return this.options({enforce_type: value});
 }
 
 

--- a/lib/type/array.js
+++ b/lib/type/array.js
@@ -27,16 +27,6 @@ TypeArray.prototype.required = function() {
 }
 
 
-TypeArray.prototype.checkType = function(isChecked, allowNull) {
-  allowNull = typeof allowNull !== 'undefined' ? allowNull : true;
-  var value = 'none';
-  if (isChecked) {
-    value = allowNull ? 'loose' : 'strict';
-  }
-  return this.options({enforce_type: value});
-}
-
-
 TypeArray.prototype.min = function(min) {
   if (min < 0) {
     throw new Error("The value for `min` must be a positive integer");

--- a/lib/type/array.js
+++ b/lib/type/array.js
@@ -12,8 +12,18 @@ function TypeArray() {
 
 
 TypeArray.prototype.options = function(options) {
-  this._options = options;
+  this._options = util.mergeOptions(this._options, options);
   return this;
+}
+
+
+TypeArray.prototype.optional = function() {
+  return this.options({enforce_missing: false});
+}
+
+
+TypeArray.prototype.required = function() {
+  return this.options({enforce_missing: true});
 }
 
 

--- a/lib/type/boolean.js
+++ b/lib/type/boolean.js
@@ -22,18 +22,13 @@ TypeBoolean.prototype.required = function() {
 }
 
 
-TypeBoolean.prototype.noTypeCheck = function() {
-  return this.options({enforce_type: 'none'});
-}
-
-
-TypeBoolean.prototype.looseTypeCheck = function() {
-  return this.options({enforce_type: 'loose'});
-}
-
-
-TypeBoolean.prototype.strictTypeCheck = function() {
-  return this.options({enforce_type: 'strict'});
+TypeBoolean.prototype.checkType = function(isChecked, allowNull) {
+  allowNull = typeof allowNull !== 'undefined' ? allowNull : true;
+  var value = 'none';
+  if (isChecked) {
+    value = allowNull ? 'loose' : 'strict';
+  }
+  return this.options({enforce_type: value});
 }
 
 

--- a/lib/type/boolean.js
+++ b/lib/type/boolean.js
@@ -22,6 +22,21 @@ TypeBoolean.prototype.required = function() {
 }
 
 
+TypeBoolean.prototype.noTypeCheck = function() {
+  return this.options({enforce_type: 'none'});
+}
+
+
+TypeBoolean.prototype.looseTypeCheck = function() {
+  return this.options({enforce_type: 'loose'});
+}
+
+
+TypeBoolean.prototype.strictTypeCheck = function() {
+  return this.options({enforce_type: 'strict'});
+}
+
+
 TypeBoolean.prototype.default = function(fnOrValue) {
   this._default = fnOrValue;
   return this;

--- a/lib/type/boolean.js
+++ b/lib/type/boolean.js
@@ -7,8 +7,18 @@ function TypeBoolean() {
 
 
 TypeBoolean.prototype.options = function(options) {
-  this._options = options;
+  this._options = util.mergeOptions(this._options, options);
   return this;
+}
+
+
+TypeBoolean.prototype.optional = function() {
+  return this.options({enforce_missing: false});
+}
+
+
+TypeBoolean.prototype.required = function() {
+  return this.options({enforce_missing: true});
 }
 
 

--- a/lib/type/boolean.js
+++ b/lib/type/boolean.js
@@ -22,16 +22,6 @@ TypeBoolean.prototype.required = function() {
 }
 
 
-TypeBoolean.prototype.checkType = function(isChecked, allowNull) {
-  allowNull = typeof allowNull !== 'undefined' ? allowNull : true;
-  var value = 'none';
-  if (isChecked) {
-    value = allowNull ? 'loose' : 'strict';
-  }
-  return this.options({enforce_type: value});
-}
-
-
 TypeBoolean.prototype.default = function(fnOrValue) {
   this._default = fnOrValue;
   return this;

--- a/lib/type/buffer.js
+++ b/lib/type/buffer.js
@@ -23,6 +23,21 @@ TypeBuffer.prototype.required = function() {
 }
 
 
+TypeBuffer.prototype.noTypeCheck = function() {
+  return this.options({enforce_type: 'none'});
+}
+
+
+TypeBuffer.prototype.looseTypeCheck = function() {
+  return this.options({enforce_type: 'loose'});
+}
+
+
+TypeBuffer.prototype.strictTypeCheck = function() {
+  return this.options({enforce_type: 'strict'});
+}
+
+
 TypeBuffer.prototype.default = function(fnOrValue) {
   this._default = fnOrValue;
   return this;

--- a/lib/type/buffer.js
+++ b/lib/type/buffer.js
@@ -8,8 +8,18 @@ function TypeBuffer() {
 
 
 TypeBuffer.prototype.options = function(options) {
-  this._options = options;
+  this._options = util.mergeOptions(this._options, options);
   return this;
+}
+
+
+TypeBuffer.prototype.optional = function() {
+  return this.options({enforce_missing: false});
+}
+
+
+TypeBuffer.prototype.required = function() {
+  return this.options({enforce_missing: true});
 }
 
 

--- a/lib/type/buffer.js
+++ b/lib/type/buffer.js
@@ -23,18 +23,13 @@ TypeBuffer.prototype.required = function() {
 }
 
 
-TypeBuffer.prototype.noTypeCheck = function() {
-  return this.options({enforce_type: 'none'});
-}
-
-
-TypeBuffer.prototype.looseTypeCheck = function() {
-  return this.options({enforce_type: 'loose'});
-}
-
-
-TypeBuffer.prototype.strictTypeCheck = function() {
-  return this.options({enforce_type: 'strict'});
+TypeBuffer.prototype.checkType = function(isChecked, allowNull) {
+  allowNull = typeof allowNull !== 'undefined' ? allowNull : true;
+  var value = 'none';
+  if (isChecked) {
+    value = allowNull ? 'loose' : 'strict';
+  }
+  return this.options({enforce_type: value});
 }
 
 

--- a/lib/type/buffer.js
+++ b/lib/type/buffer.js
@@ -23,16 +23,6 @@ TypeBuffer.prototype.required = function() {
 }
 
 
-TypeBuffer.prototype.checkType = function(isChecked, allowNull) {
-  allowNull = typeof allowNull !== 'undefined' ? allowNull : true;
-  var value = 'none';
-  if (isChecked) {
-    value = allowNull ? 'loose' : 'strict';
-  }
-  return this.options({enforce_type: value});
-}
-
-
 TypeBuffer.prototype.default = function(fnOrValue) {
   this._default = fnOrValue;
   return this;

--- a/lib/type/date.js
+++ b/lib/type/date.js
@@ -25,6 +25,21 @@ TypeDate.prototype.required = function() {
 }
 
 
+TypeDate.prototype.noTypeCheck = function() {
+  return this.options({enforce_type: 'none'});
+}
+
+
+TypeDate.prototype.looseTypeCheck = function() {
+  return this.options({enforce_type: 'loose'});
+}
+
+
+TypeDate.prototype.strictTypeCheck = function() {
+  return this.options({enforce_type: 'strict'});
+}
+
+
 TypeDate.prototype.min = function(min) {
   this._min = min;
   return this;

--- a/lib/type/date.js
+++ b/lib/type/date.js
@@ -25,18 +25,13 @@ TypeDate.prototype.required = function() {
 }
 
 
-TypeDate.prototype.noTypeCheck = function() {
-  return this.options({enforce_type: 'none'});
-}
-
-
-TypeDate.prototype.looseTypeCheck = function() {
-  return this.options({enforce_type: 'loose'});
-}
-
-
-TypeDate.prototype.strictTypeCheck = function() {
-  return this.options({enforce_type: 'strict'});
+TypeDate.prototype.checkType = function(isChecked, allowNull) {
+  allowNull = typeof allowNull !== 'undefined' ? allowNull : true;
+  var value = 'none';
+  if (isChecked) {
+    value = allowNull ? 'loose' : 'strict';
+  }
+  return this.options({enforce_type: value});
 }
 
 

--- a/lib/type/date.js
+++ b/lib/type/date.js
@@ -25,16 +25,6 @@ TypeDate.prototype.required = function() {
 }
 
 
-TypeDate.prototype.checkType = function(isChecked, allowNull) {
-  allowNull = typeof allowNull !== 'undefined' ? allowNull : true;
-  var value = 'none';
-  if (isChecked) {
-    value = allowNull ? 'loose' : 'strict';
-  }
-  return this.options({enforce_type: value});
-}
-
-
 TypeDate.prototype.min = function(min) {
   this._min = min;
   return this;

--- a/lib/type/date.js
+++ b/lib/type/date.js
@@ -10,8 +10,18 @@ function TypeDate() {
 
 
 TypeDate.prototype.options = function(options) {
-  this._options = options;
+  this._options = util.mergeOptions(this._options, options);
   return this;
+}
+
+
+TypeDate.prototype.optional = function() {
+  return this.options({enforce_missing: false});
+}
+
+
+TypeDate.prototype.required = function() {
+  return this.options({enforce_missing: true});
 }
 
 

--- a/lib/type/index.js
+++ b/lib/type/index.js
@@ -100,6 +100,15 @@ Type.prototype.virtual = function() {
 
 
 /**
+ * Create a new TypeString object to use as an id.
+ * @return {TypeVirtual}
+ */
+Type.prototype.id = function() {
+  return new TypeString().optional();
+}
+
+
+/**
  * Check if the first argument is a TypeString object or not
  * @param {Object} obj The object to check against TypeString.
  * @return {boolean}

--- a/lib/type/number.js
+++ b/lib/type/number.js
@@ -26,6 +26,21 @@ TypeNumber.prototype.required = function() {
 }
 
 
+TypeNumber.prototype.noTypeCheck = function() {
+  return this.options({enforce_type: 'none'});
+}
+
+
+TypeNumber.prototype.looseTypeCheck = function() {
+  return this.options({enforce_type: 'loose'});
+}
+
+
+TypeNumber.prototype.strictTypeCheck = function() {
+  return this.options({enforce_type: 'strict'});
+}
+
+
 TypeNumber.prototype.min = function(min) {
   if (min < 0) {
     throw new Error("The value for `min` must be a positive integer");

--- a/lib/type/number.js
+++ b/lib/type/number.js
@@ -26,18 +26,13 @@ TypeNumber.prototype.required = function() {
 }
 
 
-TypeNumber.prototype.noTypeCheck = function() {
-  return this.options({enforce_type: 'none'});
-}
-
-
-TypeNumber.prototype.looseTypeCheck = function() {
-  return this.options({enforce_type: 'loose'});
-}
-
-
-TypeNumber.prototype.strictTypeCheck = function() {
-  return this.options({enforce_type: 'strict'});
+TypeNumber.prototype.checkType = function(isChecked, allowNull) {
+  allowNull = typeof allowNull !== 'undefined' ? allowNull : true;
+  var value = 'none';
+  if (isChecked) {
+    value = allowNull ? 'loose' : 'strict';
+  }
+  return this.options({enforce_type: value});
 }
 
 

--- a/lib/type/number.js
+++ b/lib/type/number.js
@@ -8,10 +8,24 @@ function TypeNumber() {
   this._integer = false;
   this._validator = undefined;
 }
+
+
 TypeNumber.prototype.options = function(options) {
-  this._options = options;
+  this._options = util.mergeOptions(this._options, options);
   return this;
 }
+
+
+TypeNumber.prototype.optional = function() {
+  return this.options({enforce_missing: false});
+}
+
+
+TypeNumber.prototype.required = function() {
+  return this.options({enforce_missing: true});
+}
+
+
 TypeNumber.prototype.min = function(min) {
   if (min < 0) {
     throw new Error("The value for `min` must be a positive integer");
@@ -19,6 +33,8 @@ TypeNumber.prototype.min = function(min) {
   this._min = min;
   return this;
 }
+
+
 TypeNumber.prototype.max = function(max) {
   if (max < 0) {
     throw new Error("The value for `max` must be a positive integer");
@@ -26,20 +42,28 @@ TypeNumber.prototype.max = function(max) {
   this._max = max;
   return this;
 }
+
+
 TypeNumber.prototype.integer = function() {
   this._integer = true;
   return this;
 }
+
+
 TypeNumber.prototype.default = function(fnOrValue) {
   this._default = fnOrValue;
   return this;
 }
+
+
 TypeNumber.prototype.validator = function(fn) {
   if (typeof fn === "function") {
     this._validator = fn;
   }
   return this;
 }
+
+
 TypeNumber.prototype.validate = function(number, prefix, options) {
   options = util.mergeOptions(this._options, options);
 
@@ -72,6 +96,8 @@ TypeNumber.prototype.validate = function(number, prefix, options) {
     }
   }
 }
+
+
 TypeNumber.prototype._getDefaultFields = function(prefix, defaultFields, virtualFields) {
   if (this._default !== undefined) {
     defaultFields.push({

--- a/lib/type/number.js
+++ b/lib/type/number.js
@@ -26,16 +26,6 @@ TypeNumber.prototype.required = function() {
 }
 
 
-TypeNumber.prototype.checkType = function(isChecked, allowNull) {
-  allowNull = typeof allowNull !== 'undefined' ? allowNull : true;
-  var value = 'none';
-  if (isChecked) {
-    value = allowNull ? 'loose' : 'strict';
-  }
-  return this.options({enforce_type: value});
-}
-
-
 TypeNumber.prototype.min = function(min) {
   if (min < 0) {
     throw new Error("The value for `min` must be a positive integer");

--- a/lib/type/object.js
+++ b/lib/type/object.js
@@ -15,8 +15,18 @@ TypeObject.prototype._setModel = function(model) {
 
 
 TypeObject.prototype.options = function(options) {
-  this._options = options;
+  this._options = util.mergeOptions(this._options, options);
   return this;
+}
+
+
+TypeObject.prototype.optional = function() {
+  return this.options({enforce_missing: false});
+}
+
+
+TypeObject.prototype.required = function() {
+  return this.options({enforce_missing: true});
 }
 
 

--- a/lib/type/object.js
+++ b/lib/type/object.js
@@ -40,16 +40,6 @@ TypeObject.prototype.removeExtra = function() {
 }
 
 
-TypeObject.prototype.checkType = function(isChecked, allowNull) {
-  allowNull = typeof allowNull !== 'undefined' ? allowNull : true;
-  var value = 'none';
-  if (isChecked) {
-    value = allowNull ? 'loose' : 'strict';
-  }
-  return this.options({enforce_type: value});
-}
-
-
 TypeObject.prototype.schema = function(schema) {
   this._schema = schema;
   return this;

--- a/lib/type/object.js
+++ b/lib/type/object.js
@@ -29,8 +29,9 @@ TypeObject.prototype.required = function() {
   return this.options({enforce_missing: true});
 }
 
-TypeObject.prototype.allowExtra = function() {
-  return this.options({enforce_extra: 'none'});
+
+TypeObject.prototype.allowExtra = function(allowed) {
+  return this.options({enforce_extra: allowed ? 'none' : 'strict'});
 }
 
 
@@ -39,23 +40,13 @@ TypeObject.prototype.removeExtra = function() {
 }
 
 
-TypeObject.prototype.failExtra = function() {
-  return this.options({enforce_extra: 'strict'});
-}
-
-
-TypeObject.prototype.noTypeCheck = function() {
-  return this.options({enforce_type: 'none'});
-}
-
-
-TypeObject.prototype.looseTypeCheck = function() {
-  return this.options({enforce_type: 'loose'});
-}
-
-
-TypeObject.prototype.strictTypeCheck = function() {
-  return this.options({enforce_type: 'strict'});
+TypeObject.prototype.checkType = function(isChecked, allowNull) {
+  allowNull = typeof allowNull !== 'undefined' ? allowNull : true;
+  var value = 'none';
+  if (isChecked) {
+    value = allowNull ? 'loose' : 'strict';
+  }
+  return this.options({enforce_type: value});
 }
 
 

--- a/lib/type/object.js
+++ b/lib/type/object.js
@@ -29,6 +29,35 @@ TypeObject.prototype.required = function() {
   return this.options({enforce_missing: true});
 }
 
+TypeObject.prototype.allowExtra = function() {
+  return this.options({enforce_extra: 'none'});
+}
+
+
+TypeObject.prototype.removeExtra = function() {
+  return this.options({enforce_extra: 'remove'});
+}
+
+
+TypeObject.prototype.failExtra = function() {
+  return this.options({enforce_extra: 'strict'});
+}
+
+
+TypeObject.prototype.noTypeCheck = function() {
+  return this.options({enforce_type: 'none'});
+}
+
+
+TypeObject.prototype.looseTypeCheck = function() {
+  return this.options({enforce_type: 'loose'});
+}
+
+
+TypeObject.prototype.strictTypeCheck = function() {
+  return this.options({enforce_type: 'strict'});
+}
+
 
 TypeObject.prototype.schema = function(schema) {
   this._schema = schema;

--- a/lib/type/point.js
+++ b/lib/type/point.js
@@ -8,8 +8,18 @@ function TypePoint() {
 
 
 TypePoint.prototype.options = function(options) {
-  this._options = options;
+  this._options = util.mergeOptions(this._options, options);
   return this;
+}
+
+
+TypePoint.prototype.optional = function() {
+  return this.options({enforce_missing: false});
+}
+
+
+TypePoint.prototype.required = function() {
+  return this.options({enforce_missing: true});
 }
 
 

--- a/lib/type/point.js
+++ b/lib/type/point.js
@@ -23,18 +23,13 @@ TypePoint.prototype.required = function() {
 }
 
 
-TypePoint.prototype.noTypeCheck = function() {
-  return this.options({enforce_type: 'none'});
-}
-
-
-TypePoint.prototype.looseTypeCheck = function() {
-  return this.options({enforce_type: 'loose'});
-}
-
-
-TypePoint.prototype.strictTypeCheck = function() {
-  return this.options({enforce_type: 'strict'});
+TypePoint.prototype.checkType = function(isChecked, allowNull) {
+  allowNull = typeof allowNull !== 'undefined' ? allowNull : true;
+  var value = 'none';
+  if (isChecked) {
+    value = allowNull ? 'loose' : 'strict';
+  }
+  return this.options({enforce_type: value});
 }
 
 

--- a/lib/type/point.js
+++ b/lib/type/point.js
@@ -23,16 +23,6 @@ TypePoint.prototype.required = function() {
 }
 
 
-TypePoint.prototype.checkType = function(isChecked, allowNull) {
-  allowNull = typeof allowNull !== 'undefined' ? allowNull : true;
-  var value = 'none';
-  if (isChecked) {
-    value = allowNull ? 'loose' : 'strict';
-  }
-  return this.options({enforce_type: value});
-}
-
-
 TypePoint.prototype.default = function(fnOrValue) {
   this._default = fnOrValue;
   return this;

--- a/lib/type/point.js
+++ b/lib/type/point.js
@@ -23,6 +23,21 @@ TypePoint.prototype.required = function() {
 }
 
 
+TypePoint.prototype.noTypeCheck = function() {
+  return this.options({enforce_type: 'none'});
+}
+
+
+TypePoint.prototype.looseTypeCheck = function() {
+  return this.options({enforce_type: 'loose'});
+}
+
+
+TypePoint.prototype.strictTypeCheck = function() {
+  return this.options({enforce_type: 'strict'});
+}
+
+
 TypePoint.prototype.default = function(fnOrValue) {
   this._default = fnOrValue;
   return this;

--- a/lib/type/string.js
+++ b/lib/type/string.js
@@ -77,8 +77,28 @@ function TypeString() {
  * @return {TypeString}
  */
 TypeString.prototype.options = function(options) {
-  this._options = options;
+  this._options = util.mergeOptions(this._options, options);
   return this;
+}
+
+
+/**
+ * Set the property as optional (enforce_missing = false).
+ * Leaves other existing options unchanged.
+ * @return {TypeString}
+ */
+TypeString.prototype.optional = function() {
+  return this.options({enforce_missing: false});
+}
+
+
+/**
+ * Set the property as required (enforce_missing = true).
+ * Leaves other existing options unchanged.
+ * @return {TypeString}
+ */
+TypeString.prototype.required = function() {
+  return this.options({enforce_missing: true});
 }
 
 

--- a/lib/type/string.js
+++ b/lib/type/string.js
@@ -102,18 +102,20 @@ TypeString.prototype.required = function() {
 }
 
 
-TypeString.prototype.noTypeCheck = function() {
-  return this.options({enforce_type: 'none'});
-}
-
-
-TypeString.prototype.looseTypeCheck = function() {
-  return this.options({enforce_type: 'loose'});
-}
-
-
-TypeString.prototype.strictTypeCheck = function() {
-  return this.options({enforce_type: 'strict'});
+/**
+ * Turn type checking on/off.
+ * @param {boolean} isChecked Turns type checking on/off
+ * @param {boolean} allowNull If isChecked is true, then this flag
+ *                  determines whether null is an allowed value
+ * @return {TypeString}
+ */
+TypeString.prototype.checkType = function(isChecked, allowNull) {
+  allowNull = typeof allowNull !== 'undefined' ? allowNull : true;
+  var value = 'none';
+  if (isChecked) {
+    value = allowNull ? 'loose' : 'strict';
+  }
+  return this.options({enforce_type: value});
 }
 
 

--- a/lib/type/string.js
+++ b/lib/type/string.js
@@ -102,6 +102,21 @@ TypeString.prototype.required = function() {
 }
 
 
+TypeString.prototype.noTypeCheck = function() {
+  return this.options({enforce_type: 'none'});
+}
+
+
+TypeString.prototype.looseTypeCheck = function() {
+  return this.options({enforce_type: 'loose'});
+}
+
+
+TypeString.prototype.strictTypeCheck = function() {
+  return this.options({enforce_type: 'strict'});
+}
+
+
 /**
  * Set the minimum length allowed for a string.
  * @param {number} min Minimum length for the string

--- a/lib/type/string.js
+++ b/lib/type/string.js
@@ -103,23 +103,6 @@ TypeString.prototype.required = function() {
 
 
 /**
- * Turn type checking on/off.
- * @param {boolean} isChecked Turns type checking on/off
- * @param {boolean} allowNull If isChecked is true, then this flag
- *                  determines whether null is an allowed value
- * @return {TypeString}
- */
-TypeString.prototype.checkType = function(isChecked, allowNull) {
-  allowNull = typeof allowNull !== 'undefined' ? allowNull : true;
-  var value = 'none';
-  if (isChecked) {
-    value = allowNull ? 'loose' : 'strict';
-  }
-  return this.options({enforce_type: value});
-}
-
-
-/**
  * Set the minimum length allowed for a string.
  * @param {number} min Minimum length for the string
  * @return {TypeString}

--- a/lib/util.js
+++ b/lib/util.js
@@ -235,12 +235,14 @@ util.bindEmitter = bindEmitter;
 
 function mergeOptions(options, newOptions) {
   if (util.isPlainObject(newOptions)) {
+    if (!options) {
+      options = {};
+    }
     var localOptions = {};
     localOptions.enforce_missing = (newOptions.enforce_missing != null) ? newOptions.enforce_missing : options.enforce_missing;
     localOptions.enforce_type = (newOptions.enforce_type != null) ? newOptions.enforce_type : options.enforce_type;
     localOptions.enforce_extra = (newOptions.enforce_extra != null) ? newOptions.enforce_extra : options.enforce_extra;
     return localOptions;
-
   }
   else {
     return options;

--- a/test/settings.js
+++ b/test/settings.js
@@ -19,6 +19,7 @@ config['validate'] = 'oncreate';
 var thinky = require(__dirname+'/../lib/thinky.js')(config);
 var r = thinky.r;
 
+var libUtil = require(__dirname+'/../lib/util.js');
 var util = require(__dirname+'/util.js');
 var assert = require('assert');
 
@@ -174,5 +175,56 @@ describe('Priorities for options', function() {
     var Model = thinky.createModel(name, {id: {_type: String, options: {enforce_missing: false}}, name: {_type: String, options: {enforce_missing: false}}});
     var doc = new Model({})
     doc.validate();
+  });
+});
+
+describe('mergeOptions', function(){
+  it('mergeOptions - merge to an empty object', function() {
+    var newOptions = libUtil.mergeOptions(undefined, {enforce_missing: true});
+    assert.equal(newOptions.enforce_missing, true);
+    assert.equal(newOptions.enforce_extra, undefined);
+    assert.equal(newOptions.enforce_type, undefined);
+  });
+  it('mergeOptions - replace an existing option', function() {
+    var existingOptions = {enforce_missing: true};
+    var newOptions = libUtil.mergeOptions(existingOptions, {enforce_missing: false});
+    assert.equal(newOptions.enforce_missing, false);
+    assert.equal(newOptions.enforce_extra, undefined);
+    assert.equal(newOptions.enforce_type, undefined);
+  });
+  it('mergeOptions - without affecting other options - enforce_missing', function() {
+    var existingOptions = {enforce_type: "strict", enforce_extra: false};
+    var newOptions = libUtil.mergeOptions(existingOptions, {enforce_missing: true});
+    assert.equal(newOptions.enforce_missing, true);
+    assert.equal(newOptions.enforce_extra, false);
+    assert.equal(newOptions.enforce_type, "strict");
+  });
+  it('mergeOptions - without affecting other options - enforce_type', function() {
+    var existingOptions = {enforce_missing: true, enforce_extra: false};
+    var newOptions = libUtil.mergeOptions(existingOptions, {enforce_type: "loose"});
+    assert.equal(newOptions.enforce_missing, true);
+    assert.equal(newOptions.enforce_extra, false);
+    assert.equal(newOptions.enforce_type, "loose");
+  });
+  it('mergeOptions - without affecting other options - enforce_extra', function() {
+    var existingOptions = {enforce_missing: false, enforce_type: "loose"};
+    var newOptions = libUtil.mergeOptions(existingOptions, {enforce_extra: true});
+    assert.equal(newOptions.enforce_missing, false);
+    assert.equal(newOptions.enforce_extra, true);
+    assert.equal(newOptions.enforce_type, "loose");
+  });
+  it('mergeOptions - with empty new options object', function() {
+    var existingOptions = {enforce_missing: true, enforce_extra: true, enforce_type: "loose"};
+    var newOptions = libUtil.mergeOptions(existingOptions, {});
+    assert.equal(newOptions.enforce_missing, true);
+    assert.equal(newOptions.enforce_extra, true);
+    assert.equal(newOptions.enforce_type, "loose");
+  });
+  it('mergeOptions - with undefined new options object', function() {
+    var existingOptions = {enforce_missing: false, enforce_extra: false, enforce_type: "strict"};
+    var newOptions = libUtil.mergeOptions(existingOptions, undefined);
+    assert.equal(newOptions.enforce_missing, false);
+    assert.equal(newOptions.enforce_extra, false);
+    assert.equal(newOptions.enforce_type, "strict");
   });
 });


### PR DESCRIPTION
Fixes #185.
Added .id() as an alias for string().optional().
Added .optional() as an alias for .options(enforce_missing: false}).
Added .required() as an alias for .options(enforce_missing: true}).
Modified .options() to merge the given options into the existing options to allow you to write something like: ``myProp: type.string().optional().options({enforce_type: "strict"})``
Added some simple tests for mergeOptions().