### PR TITLE
New Error Type: ValidationError

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -3,6 +3,7 @@ var type =          require(__dirname+'/type/index.js');
 var util =          require(__dirname+'/util.js');
 var Promise =       require('bluebird');
 var EventEmitter =  require('events').EventEmitter;
+var Errors =        require(__dirname+'/errors.js');
 
 
 /**
@@ -247,7 +248,7 @@ Document.prototype._validateHook = function(options, modelToValidate, validateAl
 
   if (typeof self._getModel()._validator === 'function') {
     if (self._getModel()._validator.call(self, self) === false) {
-      throw new Error("Document's validator returned `false`.");
+      throw new Errors.ValidationError("Document's validator returned `false`.");
     }
   }
 
@@ -277,7 +278,7 @@ Document.prototype._validateHook = function(options, modelToValidate, validateAl
           }
         }
         else if (self[key] != null) {
-          throw new Error("Joined field "+prefix+"["+key+"] should be `undefined`, `null` or an `Object`")
+          throw new Errors.ValidationError("Joined field "+prefix+"["+key+"] should be `undefined`, `null` or an `Object`")
         }
       }
       else if (((joins[key].type === 'hasMany') || (joins[key].type === 'hasAndBelongsToMany'))) {
@@ -294,12 +295,12 @@ Document.prototype._validateHook = function(options, modelToValidate, validateAl
               }
             }
             else {
-              throw new Error("Joined field "+prefix+"["+key+"]["+i+"] should be `undefined`, `null` or an `Array`")
+              throw new Errors.ValidationError("Joined field "+prefix+"["+key+"]["+i+"] should be `undefined`, `null` or an `Array`")
             }
           }
         }
         else if (self[key] != null) {
-          throw new Error("Joined field "+prefix+"["+key+"] should be `undefined`, `null` or an `Array`")
+          throw new Errors.ValidationError("Joined field "+prefix+"["+key+"] should be `undefined`, `null` or an `Array`")
         }
       }
     }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -24,3 +24,16 @@ function InvalidWrite(message, raw) {
 InvalidWrite.prototype = new Error();
 InvalidWrite.prototype.name = "Invalid write";
 module.exports.InvalidWrite = InvalidWrite;
+
+
+/**
+ * ValidationError error which is returned when validation of a document fails.
+ * "Extends" Error
+ */
+function ValidationError(message) {
+    Error.captureStackTrace(this, ValidationError);
+    this.message = message;
+};
+ValidationError.prototype = new Error();
+ValidationError.prototype.name = "Document failed validation";
+module.exports.ValidationError = ValidationError;

--- a/lib/model.js
+++ b/lib/model.js
@@ -4,6 +4,7 @@ var Document = require(__dirname+'/document.js');
 var EventEmitter = require('events').EventEmitter;
 var Query = require(__dirname+'/query.js');
 var Promise = require('bluebird');
+var Errors = require(__dirname+'/errors.js');
 
 /*
  * Constructor for a Model. Note that this is not what `thinky.createModel`
@@ -1033,7 +1034,7 @@ Model.prototype.save = function(docs, options) {
         }
       }, function(error) {
         foundNonValidDoc = true;
-        mainReject(new Error("One of the documents is not valid. Original error:\n"+error.message))
+        mainReject(new Errors.ValidationError("One of the documents is not valid. Original error:\n"+error.message))
       });
     }
 
@@ -1049,7 +1050,7 @@ Model.prototype.save = function(docs, options) {
           mainReject(error)
         });
       }).error(function(error) {
-        mainReject(new Error("One of the documents is not valid. Original error:\n"+error.message))
+        mainReject(new Errors.ValidationError("One of the documents is not valid. Original error:\n"+error.message))
       });
     }
   })

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -3,6 +3,7 @@ module.exports.arrayPrefix = arrayPrefix;
 
 var util = require(__dirname+'/util.js');
 var type = require(__dirname+'/type/index.js');
+var Errors = require(__dirname+'/errors.js');
 
 
 function generateVirtual(doc, defaultField, originalDoc, virtual) {
@@ -114,7 +115,7 @@ function parse(schema, prefix, options, model) {
   var result;
 
   if ((prefix === '') && (type.isObject(schema) === false) && (util.isPlainObject(schema) === false)) {
-    throw new Error("The schema must be a plain object.")
+    throw new Errors.ValidationError("The schema must be a plain object.")
   }
 
   // Validate a schema and add the field _enum if needed
@@ -185,7 +186,7 @@ function parse(schema, prefix, options, model) {
           if (schema.default !== undefined) { result.default(schema.default); }
           return result
         default: // Unknown type
-          throw new Error("The field `_type` must be `String`/`Number`/`Boolean`/`Date`/`Buffer`/`Object`/`Array`/`'virtual'`/`'Point'` for "+prefix);
+          throw new Errors.ValidationError("The field `_type` must be `String`/`Number`/`Boolean`/`Date`/`Buffer`/`Object`/`Array`/`'virtual'`/`'Point'` for "+prefix);
       }
     }
     else if (type.isString(schema)
@@ -235,7 +236,7 @@ function parse(schema, prefix, options, model) {
   else if (Array.isArray(schema)) {
     result = type.array().options(options);
     if (schema.length > 1) {
-      throw new Error("An array in a schema can have at most one element. Found "+schema.length+" elements in "+prefix)
+      throw new Errors.ValidationError("An array in a schema can have at most one element. Found "+schema.length+" elements in "+prefix)
     }
 
     if (schema.length > 0) {
@@ -272,7 +273,7 @@ function parse(schema, prefix, options, model) {
     return type.virtual().options(options);
   }
   else {
-    throw new Error("The value must be `String`/`Number`/`Boolean`/`Date`/`Buffer`/`Object`/`Array`/`'virtual'`/`'Point'` for "+prefix);
+    throw new Errors.ValidationError("The value must be `String`/`Number`/`Boolean`/`Date`/`Buffer`/`Object`/`Array`/`'virtual'`/`'Point'` for "+prefix);
   }
 }
 module.exports.parse = parse;
@@ -312,14 +313,14 @@ function validateEnum(doc, schema, prefix) {
       message = message+"."
     }
 
-    throw new Error(message);
+    throw new Errors.ValidationError(message);
   }
 }
 // Check that schema is a valid object first
 function validateCustomizedValidator(doc, schema, prefix) {
   if (typeof schema.validator === 'function') {
     if (schema.validator(doc) === false) {
-      throw new Error("Validator for the field "+prefix+" returned `false`.");
+      throw new Errors.ValidationErrors.ValidationError("Validator for the field "+prefix+" returned `false`.");
     }
   }
 }
@@ -430,13 +431,13 @@ function validatePoint(doc, schema, prefix, options) {
         pseudoTypeError("Point", "type", prefix);
       }
       else if (doc.type !== "Point") {
-        throw new Error("The field `type` for "+prefix+" must be `'Point'`.")
+        throw new Errors.ValidationError("The field `type` for "+prefix+" must be `'Point'`.")
       }
       else if (doc.coordinates === undefined) {
         pseudoTypeError("date", "coordinates", prefix);
       }
       else if ((!Array.isArray(doc.coordinates)) || (doc.coordinates.length !== 2)) {
-        throw new Error("The field `coordinates` for "+prefix+" must be an Array of two numbers.")
+        throw new Errors.ValidationError("The field `coordinates` for "+prefix+" must be an Array of two numbers.")
       }
     }
     else if (util.isPlainObject(doc) && (doc.type === "Point") && (Array.isArray(doc.coordinates)) && (doc.coordinates.length === 2)) { // Geojson
@@ -449,15 +450,15 @@ function validatePoint(doc, schema, prefix, options) {
     else if (util.isPlainObject(doc)) {
       var keys = Object.keys(doc).sort();
       if (((keys.length !== 2) || keys[0] !== 'latitude') || (keys[1] !== 'longitude') || (typeof doc.latitude !== "number") || (typeof doc.longitude !== "number")) {
-        throw new Error("The value for "+prefix+" must be a ReQL Point (`r.point(<longitude>, <latitude>)`), an object `{longitude: <number>, latitude: <number>}`, or an array [<longitude>, <latitude>].")
+        throw new Errors.ValidationError("The value for "+prefix+" must be a ReQL Point (`r.point(<longitude>, <latitude>)`), an object `{longitude: <number>, latitude: <number>}`, or an array [<longitude>, <latitude>].")
       }
       else if ((typeof doc.latitude !== 'number') || (typeof doc.latitude !== 'number')) {
-        throw new Error("The value for "+prefix+" must be a ReQL Point (`r.point(<longitude>, <latitude>)`), an object `{longitude: <number>, latitude: <number>}`, or an array [<longitude>, <latitude>].")
+        throw new Errors.ValidationError("The value for "+prefix+" must be a ReQL Point (`r.point(<longitude>, <latitude>)`), an object `{longitude: <number>, latitude: <number>}`, or an array [<longitude>, <latitude>].")
       }
     }
     else if (Array.isArray(doc)) {
       if ((doc.length !== 2) || (typeof doc[0] !== "number") || (typeof doc[1] !== "number")) {
-        throw new Error("The value for "+prefix+" must be a ReQL Point (`r.point(<longitude>, <latitude>)`), an object `{longitude: <number>, latitude: <number>}`, or an array [<longitude>, <latitude>].")
+        throw new Errors.ValidationError("The value for "+prefix+" must be a ReQL Point (`r.point(<longitude>, <latitude>)`), an object `{longitude: <number>, latitude: <number>}`, or an array [<longitude>, <latitude>].")
       }
     }
   }

--- a/lib/type/array.js
+++ b/lib/type/array.js
@@ -1,6 +1,7 @@
 var util = require(__dirname+'/../util.js');
 var schema =      require(__dirname+'/../schema.js');
 var arrayPrefix = schema.arrayPrefix;
+var Errors = require(__dirname+'/../errors.js');
 
 function TypeArray() {
   this._min = -1;
@@ -19,7 +20,7 @@ TypeArray.prototype.options = function(options) {
 
 TypeArray.prototype.min = function(min) {
   if (min < 0) {
-    throw new Error("The value for `min` must be a positive integer");
+    throw new Errors.ValidationError("The value for `min` must be a positive integer");
   }
   this._min = min;
   return this;
@@ -28,7 +29,7 @@ TypeArray.prototype.min = function(min) {
 
 TypeArray.prototype.max = function(max) {
   if (max < 0) {
-    throw new Error("The value for `max` must be a positive integer");
+    throw new Errors.ValidationError("The value for `max` must be a positive integer");
   }
   this._max = max;
   return this;
@@ -37,7 +38,7 @@ TypeArray.prototype.max = function(max) {
 
 TypeArray.prototype.length = function(length) {
   if (length < 0) {
-    throw new Error("The value for `length` must be a positive integer");
+    throw new Errors.ValidationError("The value for `length` must be a positive integer");
   }
   this._length = length;
   return this;
@@ -69,7 +70,7 @@ TypeArray.prototype.validate = function(array, prefix, options) {
   if (util.validateIfUndefined(array, prefix, "array", options)) return;
 
   if ((typeof self._validator === "function") && (self._validator(array) === false)) {
-    throw new Error("Validator for the field "+prefix+" returned `false`.");
+    throw new Errors.ValidationError("Validator for the field "+prefix+" returned `false`.");
   }
 
   if ((typeof array === 'function') && (array._query !== undefined)) {
@@ -85,18 +86,18 @@ TypeArray.prototype.validate = function(array, prefix, options) {
   }
   else {
     if ((this._min !== -1) && (this._min > array.length)){
-      throw new Error("Value for "+prefix+" must have at least "+this._min+" elements.") 
+      throw new Errors.ValidationError("Value for "+prefix+" must have at least "+this._min+" elements.") 
     }
     if ((this._max !== -1) && (this._max < array.length)){
-      throw new Error("Value for "+prefix+" must have at most "+this._max+" elements.") 
+      throw new Errors.ValidationError("Value for "+prefix+" must have at most "+this._max+" elements.") 
     }
     if ((this._length !== -1) && (this._length !== array.length)){
-      throw new Error("Value for "+prefix+" must be an array with "+this._length+" elements.") 
+      throw new Errors.ValidationError("Value for "+prefix+" must be an array with "+this._length+" elements.") 
     }
 
     for(var i=0; i<array.length; i++) {
       if (array[i] === undefined) {
-        throw new Error("The element in the array "+prefix+" (position "+i+") cannot be `undefined`.");
+        throw new Errors.ValidationError("The element in the array "+prefix+" (position "+i+") cannot be `undefined`.");
       }
       if (this._schema !== undefined) {
         this._schema.validate(array[i], prefix+"["+i+"]", options);

--- a/lib/type/boolean.js
+++ b/lib/type/boolean.js
@@ -1,5 +1,5 @@
 var util = require(__dirname+'/../util.js');
-
+var Errors = require(__dirname+'/../errors.js');
 
 function TypeBoolean() {
   this._validator = undefined;
@@ -32,7 +32,7 @@ TypeBoolean.prototype.validate = function(bool, prefix, options) {
   if (util.validateIfUndefined(bool, prefix, "boolean", options)) return;
 
   if ((typeof this._validator === "function") && (this._validator(bool) === false)) {
-    throw new Error("Validator for the field "+prefix+" returned `false`.");
+    throw new Errors.ValidationError("Validator for the field "+prefix+" returned `false`.");
   }
 
   if (typeof bool !== "boolean") {

--- a/lib/type/buffer.js
+++ b/lib/type/buffer.js
@@ -1,5 +1,5 @@
 var util = require(__dirname+'/../util.js');
-
+var Errors = require(__dirname+'/../errors.js');
 
 function TypeBuffer() {
   this._options = undefined;
@@ -33,7 +33,7 @@ TypeBuffer.prototype.validate = function(buffer, prefix, options) {
   if (util.validateIfUndefined(buffer, prefix, "buffer", options)) return;
 
   if ((typeof this._validator === "function") && (this._validator(buffer) === false)) {
-    throw new Error("Validator for the field "+prefix+" returned `false`.");
+    throw new Errors.ValidationError("Validator for the field "+prefix+" returned `false`.");
   }
 
   if (util.isPlainObject(buffer) && (buffer["$reql_type$"] === "BINARY")) {

--- a/lib/type/date.js
+++ b/lib/type/date.js
@@ -1,5 +1,5 @@
 var util = require(__dirname+'/../util.js');
-
+var Errors = require(__dirname+'/../errors.js');
 
 function TypeDate() {
   this._options = undefined;
@@ -47,7 +47,7 @@ TypeDate.prototype.validate = function(date, prefix, options) {
   if (util.validateIfUndefined(date, prefix, "date", options)) return;
 
   if ((typeof this._validator === "function") && (this._validator(date) === false)) {
-    throw new Error("Validator for the field "+prefix+" returned `false`.");
+    throw new Errors.ValidationError("Validator for the field "+prefix+" returned `false`.");
   }
 
   var jsDate;
@@ -92,10 +92,10 @@ TypeDate.prototype.validate = function(date, prefix, options) {
   // We check for min/max only if we could create a javascript date from the value
   if (jsDate !== undefined) {
     if ((this._min instanceof Date) && (this._min > jsDate)){
-      throw new Error("Value for "+prefix+" must be after "+this._min+".") 
+      throw new Errors.ValidationError("Value for "+prefix+" must be after "+this._min+".") 
     }
     if ((this._max instanceof Date) && (this._max < jsDate)){
-      throw new Error("Value for "+prefix+" must be before "+this._max+".") 
+      throw new Errors.ValidationError("Value for "+prefix+" must be before "+this._max+".") 
     }
   }
 }

--- a/lib/type/number.js
+++ b/lib/type/number.js
@@ -1,5 +1,5 @@
 var util = require(__dirname+'/../util.js');
-
+var Errors = require(__dirname+'/../errors.js');
 
 function TypeNumber() {
   this._options = undefined;
@@ -14,14 +14,14 @@ TypeNumber.prototype.options = function(options) {
 }
 TypeNumber.prototype.min = function(min) {
   if (min < 0) {
-    throw new Error("The value for `min` must be a positive integer");
+    throw new Errors.ValidationError("The value for `min` must be a positive integer");
   }
   this._min = min;
   return this;
 }
 TypeNumber.prototype.max = function(max) {
   if (max < 0) {
-    throw new Error("The value for `max` must be a positive integer");
+    throw new Errors.ValidationError("The value for `max` must be a positive integer");
   }
   this._max = max;
   return this;
@@ -46,7 +46,7 @@ TypeNumber.prototype.validate = function(number, prefix, options) {
   if (util.validateIfUndefined(number, prefix, "number", options)) return;
   
   if ((typeof this._validator === "function") && (this._validator(number) === false)) {
-    throw new Error("Validator for the field "+prefix+" returned `false`.");
+    throw new Errors.ValidationError("Validator for the field "+prefix+" returned `false`.");
   }
 
   if ((typeof number === 'function') && (number._query !== undefined)) {
@@ -62,13 +62,13 @@ TypeNumber.prototype.validate = function(number, prefix, options) {
   }
   else {
     if ((this._min !== -1) && (this._min > number)){
-      throw new Error("Value for "+prefix+" must be greater than "+this._min+".") 
+      throw new Errors.ValidationError("Value for "+prefix+" must be greater than "+this._min+".") 
     }
     if ((this._max !== -1) && (this._max < number)){
-      throw new Error("Value for "+prefix+" must be less than "+this._max+".") 
+      throw new Errors.ValidationError("Value for "+prefix+" must be less than "+this._max+".") 
     }
     if ((this._integer === true) && (number%1 !== 0)){
-      throw new Error("Value for "+prefix+" must be an integer.") 
+      throw new Errors.ValidationError("Value for "+prefix+" must be an integer.") 
     }
   }
 }

--- a/lib/type/object.js
+++ b/lib/type/object.js
@@ -1,5 +1,5 @@
 var util = require(__dirname+'/../util.js');
-
+var Errors = require(__dirname+'/../errors.js');
 
 function TypeObject() {
   this._options = undefined;
@@ -53,7 +53,7 @@ TypeObject.prototype.validate = function(object, prefix, options) {
   if (util.validateIfUndefined(object, prefix, "object", localOptions)) return;
 
   if ((typeof self._validator === "function") && (self._validator(object) === false)) {
-    throw new Error("Validator for the field "+prefix+" returned `false`.");
+    throw new Errors.ValidationError("Validator for the field "+prefix+" returned `false`.");
   }
 
   if ((typeof object === 'function') && (object._query !== undefined)) {

--- a/lib/type/point.js
+++ b/lib/type/point.js
@@ -1,5 +1,5 @@
 var util = require(__dirname+'/../util.js');
-
+var Errors = require(__dirname+'/../errors.js');
 
 function TypePoint() {
   this._options = undefined;
@@ -33,7 +33,7 @@ TypePoint.prototype.validate = function(point, prefix, options) {
   if (util.validateIfUndefined(point, prefix, "point", options)) return;
 
   if ((typeof this._validator === "function") && (this._validator(point) === false)) {
-    throw new Error("Validator for the field "+prefix+" returned `false`.");
+    throw new Errors.ValidationError("Validator for the field "+prefix+" returned `false`.");
   }
 
   if (util.isPlainObject(point) && (point["$reql_type$"] === "GEOMETRY")) {
@@ -41,13 +41,13 @@ TypePoint.prototype.validate = function(point, prefix, options) {
       util.pseudoTypeError("Point", "type", prefix);
     }
     else if (point.type !== "Point") {
-      throw new Error("The field `type` for "+prefix+" must be `'Point'`.")
+      throw new Errors.ValidationError("The field `type` for "+prefix+" must be `'Point'`.")
     }
     else if (point.coordinates === undefined) {
       util.pseudoTypeError("date", "coordinates", prefix);
     }
     else if ((!Array.isArray(point.coordinates)) || (point.coordinates.length !== 2)) {
-      throw new Error("The field `coordinates` for "+prefix+" must be an Array of two numbers.")
+      throw new Errors.ValidationError("The field `coordinates` for "+prefix+" must be an Array of two numbers.")
     }
   }
   else if (util.isPlainObject(point) && (point.type === "Point") && (Array.isArray(point.coordinates)) && (point.coordinates.length === 2)) { // Geojson
@@ -60,15 +60,15 @@ TypePoint.prototype.validate = function(point, prefix, options) {
   else if (util.isPlainObject(point)) {
     var keys = Object.keys(point).sort();
     if (((keys.length !== 2) || keys[0] !== 'latitude') || (keys[1] !== 'longitude') || (typeof point.latitude !== "number") || (typeof point.longitude !== "number")) {
-      throw new Error("The value for "+prefix+" must be a ReQL Point (`r.point(<longitude>, <latitude>)`), an object `{longitude: <number>, latitude: <number>}`, or an array [<longitude>, <latitude>].")
+      throw new Errors.ValidationError("The value for "+prefix+" must be a ReQL Point (`r.point(<longitude>, <latitude>)`), an object `{longitude: <number>, latitude: <number>}`, or an array [<longitude>, <latitude>].")
     }
     else if ((typeof point.latitude !== 'number') || (typeof point.latitude !== 'number')) {
-      throw new Error("The value for "+prefix+" must be a ReQL Point (`r.point(<longitude>, <latitude>)`), an object `{longitude: <number>, latitude: <number>}`, or an array [<longitude>, <latitude>].")
+      throw new Errors.ValidationError("The value for "+prefix+" must be a ReQL Point (`r.point(<longitude>, <latitude>)`), an object `{longitude: <number>, latitude: <number>}`, or an array [<longitude>, <latitude>].")
     }
   }
   else if (Array.isArray(point)) {
     if ((point.length !== 2) || (typeof point[0] !== "number") || (typeof point[1] !== "number")) {
-      throw new Error("The value for "+prefix+" must be a ReQL Point (`r.point(<longitude>, <latitude>)`), an object `{longitude: <number>, latitude: <number>}`, or an array [<longitude>, <latitude>].")
+      throw new Errors.ValidationError("The value for "+prefix+" must be a ReQL Point (`r.point(<longitude>, <latitude>)`), an object `{longitude: <number>, latitude: <number>}`, or an array [<longitude>, <latitude>].")
     }
   }
   else { // We don't have a point

--- a/lib/type/string.js
+++ b/lib/type/string.js
@@ -1,6 +1,6 @@
 var util =       require(__dirname+'/../util.js');
 var validator =  require("validator");
-
+var Errors = require(__dirname+'/../errors.js');
 
 /**
  * Create a new TypeString object
@@ -89,7 +89,7 @@ TypeString.prototype.options = function(options) {
  */
 TypeString.prototype.min = function(min) {
   if (min < 0) {
-    throw new Error("The value for `min` must be a positive integer");
+    throw new Errors.ValidationError("The value for `min` must be a positive integer");
   }
   this._min = min;
   return this;
@@ -103,7 +103,7 @@ TypeString.prototype.min = function(min) {
  */
 TypeString.prototype.max = function(max) {
   if (max < 0) {
-    throw new Error("The value for `max` must be a positive integer");
+    throw new Errors.ValidationError("The value for `max` must be a positive integer");
   }
   this._max = max;
   return this;
@@ -117,7 +117,7 @@ TypeString.prototype.max = function(max) {
  */
 TypeString.prototype.length = function(length) {
   if (length < 0) {
-    throw new Error("The value for `length` must be a positive integer");
+    throw new Errors.ValidationError("The value for `length` must be a positive integer");
   }
   this._length = length;
   return this;
@@ -244,7 +244,7 @@ TypeString.prototype.validate = function(str, prefix, options) {
   if (util.validateIfUndefined(str, prefix, "string", options)) return;
 
   if ((typeof this._validator === "function") && (this._validator(str) === false)) {
-    throw new Error("Validator for the field "+prefix+" returned `false`.");
+    throw new Errors.ValidationError("Validator for the field "+prefix+" returned `false`.");
   }
 
 
@@ -261,28 +261,28 @@ TypeString.prototype.validate = function(str, prefix, options) {
   }
   else {
     if ((this._min !== -1) && (this._min > str.length)){
-      throw new Error("Value for "+prefix+" must be longer than "+this._min+".") 
+      throw new Errors.ValidationError("Value for "+prefix+" must be longer than "+this._min+".") 
     }
     if ((this._max !== -1) && (this._max < str.length)){
-      throw new Error("Value for "+prefix+" must be shorter than "+this._max+".") 
+      throw new Errors.ValidationError("Value for "+prefix+" must be shorter than "+this._max+".") 
     }
     if ((this._length !== -1) && (this._length !== str.length)){
-      throw new Error("Value for "+prefix+" must be a string with "+this._length+" characters.") 
+      throw new Errors.ValidationError("Value for "+prefix+" must be a string with "+this._length+" characters.") 
     }
     if ((this._regex instanceof RegExp) && (this._regex.test(str) === false)) {
-      throw new Error("Value for "+prefix+" must match the regex.") 
+      throw new Errors.ValidationError("Value for "+prefix+" must match the regex.") 
     }
     if ((this._alphanum === true) && (validator.isAlphanumeric(str) === false)) {
-      throw new Error("Value for "+prefix+" must be an alphanumeric string.") 
+      throw new Errors.ValidationError("Value for "+prefix+" must be an alphanumeric string.") 
     }
     if ((this._email === true) && (validator.isEmail(str) === false)) {
-      throw new Error("Value for "+prefix+" must be a valid email.") 
+      throw new Errors.ValidationError("Value for "+prefix+" must be a valid email.") 
     }
     if ((this._lowercase === true) && (validator.isLowercase(str) === false)) {
-      throw new Error("Value for "+prefix+" must be a lowercase string.") 
+      throw new Errors.ValidationError("Value for "+prefix+" must be a lowercase string.") 
     }
     if ((this._uppercase === true) && (validator.isUppercase(str) === false)) {
-      throw new Error("Value for "+prefix+" must be a uppercase string.") 
+      throw new Errors.ValidationError("Value for "+prefix+" must be a uppercase string.") 
     }
     if ((this._enum !== undefined) && (this._enum[str] !== true)) {
       var validValues = Object.keys(this._enum);
@@ -304,7 +304,7 @@ TypeString.prototype.validate = function(str, prefix, options) {
         message = message+"."
       }
 
-      throw new Error(message);
+      throw new Errors.ValidationError(message);
     }
   }
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,7 @@
 var util = require('util');
 var Promise = require('bluebird');
 var EventEmitter = require('events').EventEmitter;
+var Errors = require(__dirname+'/errors.js');
 
 /**
  * Random useful methods used everywhere.
@@ -265,7 +266,7 @@ util.extractPrimaryKey = extractPrimaryKey;
 
 
 function undefinedField(prefix) {
-  throw new Error("Value for "+prefix+" must be defined.")
+  throw new Errors.ValidationError("Value for "+prefix+" must be defined.")
 }
 util.undefinedField = undefinedField;
 
@@ -273,10 +274,10 @@ util.undefinedField = undefinedField;
 var vowels = {a: true, e: true, i: true, o: true, u: true};
 function strictType(prefix, expected) {
   if ((expected.length > 0) && (vowels[expected[0]])) {
-    throw new Error("Value for "+prefix+" must be an "+expected+".")
+    throw new Errors.ValidationError("Value for "+prefix+" must be an "+expected+".")
   }
   else {
-    throw new Error("Value for "+prefix+" must be a "+expected+".")
+    throw new Errors.ValidationError("Value for "+prefix+" must be a "+expected+".")
   }
 }
 util.strictType = strictType;
@@ -284,10 +285,10 @@ util.strictType = strictType;
 
 function extraField(prefix, key) {
   if (prefix === '') {
-    throw new Error("Extra field `"+key+"` not allowed.")
+    throw new Errors.ValidationError("Extra field `"+key+"` not allowed.")
   }
   else {
-    throw new Error("Extra field `"+key+"` in "+prefix+" not allowed.")
+    throw new Errors.ValidationError("Extra field `"+key+"` in "+prefix+" not allowed.")
   }
 }
 util.extraField = extraField;
@@ -295,17 +296,17 @@ util.extraField = extraField;
 
 function looseType(prefix, expected) {
   if ((expected.length > 0) && (vowels[expected[0]])) {
-    throw new Error("Value for "+prefix+" must be an "+expected+" or null.")
+    throw new Errors.ValidationError("Value for "+prefix+" must be an "+expected+" or null.")
   }
   else {
-    throw new Error("Value for "+prefix+" must be a "+expected+" or null.")
+    throw new Errors.ValidationError("Value for "+prefix+" must be a "+expected+" or null.")
   }
 }
 util.looseType = looseType;
 
 
 function pseudoTypeError(type, missingField, prefix) {
-  throw new Error("The raw "+type+" object for "+prefix+" is missing the required field "+missingField+".")
+  throw new Errors.ValidationError("The raw "+type+" object for "+prefix+" is missing the required field "+missingField+".")
 }
 util.pseudoTypeError = pseudoTypeError;
 

--- a/test/document.js
+++ b/test/document.js
@@ -1358,6 +1358,16 @@ describe('save', function() {
         done();
       });
     });
+    it('should throw a ValidationError', function(done) {
+      var Model = thinky.createModel(modelNames[0], {id: Date});
+      var doc = new Model({id: "notADate"});
+      doc.save().then(function() {
+        done(new Error("Was expecting an error"));
+      }).error(function(error) {
+        assert(error instanceof Errors.ValidationError)
+        done();
+      });
+    });
   });
 });
 
@@ -2800,6 +2810,7 @@ describe('hooks', function() {
           done(new Error("Was expecting an error"))
         }).error(function(err) {
           assert.equal(err.message, "Value for [id] must be a string or null.");
+          assert(err instanceof Errors.ValidationError);
           done();
         });
       }).error(done);

--- a/test/model.js
+++ b/test/model.js
@@ -2,6 +2,7 @@ var config = require(__dirname+'/../config.js');
 var thinky = require(__dirname+'/../lib/thinky.js')(config);
 var r = thinky.r;
 var type = thinky.type;
+var Errors = thinky.Errors;
 
 var util = require(__dirname+'/util.js');
 var assert = require('assert');
@@ -213,7 +214,8 @@ describe("Batch insert", function() {
       num: Number
     });
     Model.save([{id: 4}]).error(function(err) {
-      assert.equal(err.message, "One of the documents is not valid. Original error:\nValue for [id] must be a string or null.")
+      assert.equal(err.message, "One of the documents is not valid. Original error:\nValue for [id] must be a string or null.");
+      assert(err instanceof Errors.ValidationError);
       done();
     });
   });

--- a/test/schema.js
+++ b/test/schema.js
@@ -2,6 +2,7 @@ var config = require(__dirname+'/../config.js');
 var thinky = require(__dirname+'/../lib/thinky.js')(config);
 var r = thinky.r;
 var type = thinky.type;
+var Errors = thinky.Errors;
 
 var util = require(__dirname+'/util.js');
 var assert = require('assert');
@@ -176,7 +177,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 1 });
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be a string or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be a string or null.")
     });
   });
   it('String - basic - null', function(){
@@ -196,7 +197,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: null});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be a string.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be a string.")
     });
   });
   it('String - basic - undefined', function(){
@@ -216,7 +217,7 @@ describe('Chainable types', function(){
       var doc = new Model({});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be defined.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be defined.")
     });
   });
   it('String - r.uuid', function(){
@@ -236,7 +237,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 'a'});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be longer than 2."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be longer than 2."); 
     });
   });
   it('String - min - good', function(){
@@ -256,7 +257,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 'abcdefgh'});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be shorter than 5."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be shorter than 5."); 
     });
   });
   it('String - max - good', function(){
@@ -276,7 +277,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 'abcdef'});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be a string with 5 characters."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be a string with 5 characters."); 
     });
   });
   it('String - length - too short', function(){
@@ -288,7 +289,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 'abc'});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be a string with 5 characters."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be a string with 5 characters."); 
     });
   });
   it('String - length - good', function(){
@@ -308,7 +309,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 'bar'});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must match the regex."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must match the regex."); 
     });
   });
   it('String - regex - good', function(){
@@ -328,7 +329,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 'bar'});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must match the regex."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must match the regex."); 
     });
   });
   it('String - regex with flags - good', function(){
@@ -350,7 +351,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 'élégant'});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be an alphanumeric string."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be an alphanumeric string."); 
     });
   });
   it('String - alphanum - match', function(){
@@ -370,7 +371,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 'fooATbar.com'});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be a valid email."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be a valid email."); 
     });
   });
   it('String - email - match', function(){
@@ -390,7 +391,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 'fooBar'});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be a lowercase string."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be a lowercase string."); 
     });
   });
   it('String - lowercase - match', function(){
@@ -410,7 +411,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 'fooBar'});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be a uppercase string."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be a uppercase string."); 
     });
   });
   it('String - uppercase - match', function(){
@@ -430,7 +431,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 'fooBar'});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Validator for the field [id] returned `false`."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Validator for the field [id] returned `false`."); 
     });
   });
   it('String - validator - return true', function(){
@@ -444,13 +445,13 @@ describe('Chainable types', function(){
   it('String - validator - throw', function(){
     var name = util.s8();
     var Model = thinky.createModel(name,
-      {id: type.string().validator(function() { throw new Error("Not good") }) },
+      {id: type.string().validator(function() { throw new Errors.ValidationError("Not good") }) },
       {init: false})
     assert.throws(function() {
       var doc = new Model({ id: 'fooBar'});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Not good"); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Not good"); 
     });
   });
   it('String - enum - unknown value - 1', function(){
@@ -462,7 +463,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 'buzz'});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "The field [id] must be one of these values: foo, bar."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "The field [id] must be one of these values: foo, bar."); 
     });
   });
   it('String - enum - unknown value - 2', function(){
@@ -474,7 +475,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 'buzz'});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "The field [id] must be one of these values: foo, bar."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "The field [id] must be one of these values: foo, bar."); 
     });
   });
   it('String - enum - unknown value - 3', function(){
@@ -486,7 +487,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 'buzz'});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "The field [id] must be one of these values: foo."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "The field [id] must be one of these values: foo."); 
     });
   });
   it('String - enum - unknown value - 4', function(){
@@ -498,7 +499,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 'buzz'});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "The field [id] must be one of these values: foo."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "The field [id] must be one of these values: foo."); 
     });
   });
 
@@ -551,7 +552,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: "foo" });
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be a finite number or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be a finite number or null.")
     });
   });
   it('Number - basic - NaN', function(){
@@ -563,7 +564,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: NaN });
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be a finite number or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be a finite number or null.")
     });
   });
   it('Number - r.random()', function(){
@@ -583,7 +584,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: Infinity });
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be a finite number or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be a finite number or null.")
     });
   });
   it('Number - basic - -Infinity', function(){
@@ -595,7 +596,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: -Infinity });
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be a finite number or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be a finite number or null.")
     });
   });
   it('Number - min - too small', function(){
@@ -607,7 +608,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 1});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be greater than 2."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be greater than 2."); 
     });
   });
   it('Number - min - good', function(){
@@ -627,7 +628,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 8});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be less than 5."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be less than 5."); 
     });
   });
   it('Number - max - good', function(){
@@ -647,7 +648,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 3.14});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be an integer."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be an integer."); 
     });
   });
   it('Number - integer - good', function(){
@@ -667,7 +668,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 2});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Validator for the field [id] returned `false`."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Validator for the field [id] returned `false`."); 
     });
   });
   it('Number - validator - return true', function(){
@@ -681,13 +682,13 @@ describe('Chainable types', function(){
   it('Number - validator - throw', function(){
     var name = util.s8();
     var Model = thinky.createModel(name,
-      {id: type.number().validator(function() { throw new Error("Not good") }) },
+      {id: type.number().validator(function() { throw new Errors.ValidationError("Not good") }) },
       {init: false})
     assert.throws(function() {
       var doc = new Model({ id: 4});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Not good"); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Not good"); 
     });
   });
 
@@ -707,7 +708,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: "foo" });
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be a boolean or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be a boolean or null.")
     });
   });
   it('Boolean - validator - return false', function(){
@@ -719,7 +720,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: true});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Validator for the field [id] returned `false`."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Validator for the field [id] returned `false`."); 
     });
   });
   it('Boolean - validator - return true', function(){
@@ -733,13 +734,13 @@ describe('Chainable types', function(){
   it('Boolean - validator - throw', function(){
     var name = util.s8();
     var Model = thinky.createModel(name,
-      {id: type.number().validator(function() { throw new Error("Not good") }) },
+      {id: type.number().validator(function() { throw new Errors.ValidationError("Not good") }) },
       {init: false})
     assert.throws(function() {
       var doc = new Model({ id: true});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Not good"); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Not good"); 
     });
   });
 
@@ -768,7 +769,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: "foo" });
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be a date or a valid string or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be a date or a valid string or null.")
     });
   });
   it('Date - min - too small', function(){
@@ -785,7 +786,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: valueDate});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && ((error.message.match("Value for .id. must be after")) !== null); 
+      return (error instanceof Errors.ValidationError) && ((error.message.match("Value for .id. must be after")) !== null); 
     });
   });
   it('Date - min - good', function(){
@@ -815,7 +816,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: valueDate});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && ((error.message.match("Value for .id. must be before")) !== null); 
+      return (error instanceof Errors.ValidationError) && ((error.message.match("Value for .id. must be before")) !== null); 
     });
   });
   it('Date - max - good', function(){
@@ -840,7 +841,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: new Date()});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Validator for the field [id] returned `false`."); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Validator for the field [id] returned `false`."); 
     });
   });
   it('Date - validator - return true', function(){
@@ -854,13 +855,13 @@ describe('Chainable types', function(){
   it('Date - validator - throw', function(){
     var name = util.s8();
     var Model = thinky.createModel(name,
-      {id: type.date().validator(function() { throw new Error("Not good") }) },
+      {id: type.date().validator(function() { throw new Errors.ValidationError("Not good") }) },
       {init: false})
     assert.throws(function() {
       var doc = new Model({ id: new Date()});
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Not good"); 
+      return (error instanceof Errors.ValidationError) && (error.message === "Not good"); 
     });
   });
 
@@ -889,7 +890,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: "foo" });
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be a buffer or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be a buffer or null.")
     });
   });
 
@@ -916,7 +917,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: "foo" });
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be a Point or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be a Point or null.")
     });
   });
   it('Object - basic - valid object', function(){
@@ -939,7 +940,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: "foo" });
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be an object or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be an object or null.")
     });
   });
 
@@ -959,7 +960,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: "foo" });
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be an array or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be an array or null.")
     });
   });
   it('Array - basic - wrong nested type - 1', function(){
@@ -971,7 +972,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: [2] });
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id][0] must be a string or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id][0] must be a string or null.")
     });
   });
   it('Array - basic - wrong nested type - 2', function(){
@@ -983,7 +984,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: [2] });
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id][0] must be a string or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id][0] must be a string or null.")
     });
   });
   it('Array - basic - wrong nested type - 3', function(){
@@ -995,7 +996,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: [2] });
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id][0] must be a string or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id][0] must be a string or null.")
     });
   });
   it('Array - min - good', function(){
@@ -1015,7 +1016,7 @@ describe('Chainable types', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must have at least 2 elements.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must have at least 2 elements.")
     });
   });
   it('Array - max - good', function(){
@@ -1035,7 +1036,7 @@ describe('Chainable types', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must have at most 2 elements.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must have at most 2 elements.")
     });
   });
   it('Array - length - good', function(){
@@ -1055,7 +1056,7 @@ describe('Chainable types', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [id] must be an array with 2 elements.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be an array with 2 elements.")
     });
   });
 
@@ -1575,7 +1576,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be a string.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be a string.")
     });
   });
   it('String - wrong type  - type: "loose"', function(){
@@ -1595,7 +1596,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be a string or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be a string or null.")
     });
 
   });
@@ -1679,7 +1680,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be defined.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be defined.")
     });
   });
   it('String - null - type: "strict"', function(){
@@ -1699,7 +1700,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be a string.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be a string.")
     });
   });
   it('String - null  - type: "loose"', function(){
@@ -1751,7 +1752,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be a finite number.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be a finite number.")
     });
   });
   it('Number - wrong type  - type: "loose"', function(){
@@ -1771,7 +1772,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be a finite number or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be a finite number or null.")
     });
 
   });
@@ -1808,7 +1809,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be a boolean.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be a boolean.")
     });
   });
   it('Boolean - wrong type  - type: "loose"', function(){
@@ -1828,7 +1829,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be a boolean or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be a boolean or null.")
     });
 
   });
@@ -1881,7 +1882,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be a date or a valid string.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be a date or a valid string.")
     });
   });
   it('Date - wrong type  - type: "loose"', function(){
@@ -1901,7 +1902,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be a date or a valid string or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be a date or a valid string or null.")
     });
   });
   it('Date - string type - type: "loose"', function(){
@@ -1968,7 +1969,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "The raw date object for [field] is missing the required field timezone.")
+      return (error instanceof Errors.ValidationError) && (error.message === "The raw date object for [field] is missing the required field timezone.")
     });
   });
   it('Date - raw type - missing epoch_time - type: "strict"', function(){
@@ -1987,7 +1988,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "The raw date object for [field] is missing the required field epoch_time.")
+      return (error instanceof Errors.ValidationError) && (error.message === "The raw date object for [field] is missing the required field epoch_time.")
     });
   });
   it('Date - r.now', function(){
@@ -2020,7 +2021,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be defined.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be defined.")
     });
   });
   it('Date - undefined - enforce_missing: false', function(){
@@ -2070,7 +2071,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be a buffer.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be a buffer.")
     });
   });
   it('Buffer - wrong type  - type: "loose"', function(){
@@ -2090,7 +2091,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be a buffer or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be a buffer or null.")
     });
   });
 
@@ -2142,7 +2143,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "The raw binary object for [field] is missing the required field data.")
+      return (error instanceof Errors.ValidationError) && (error.message === "The raw binary object for [field] is missing the required field data.")
     });
   });
   it('Buffer - r.http', function(){
@@ -2175,7 +2176,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be defined.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be defined.")
     });
   });
   it('Buffer - undefined - enforce_missing: false', function(){
@@ -2208,7 +2209,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be defined.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be defined.")
     });
   });
   it('Array - undefined - enforce_missing: true', function(){
@@ -2227,7 +2228,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be defined.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be defined.")
     });
   });
   it('Array - undefined - enforce_missing: false', function(){
@@ -2262,7 +2263,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be an array or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be an array or null.")
     });
   });
   it('Array - wrong type - enforce_type: "loose"', function(){
@@ -2282,7 +2283,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be an array or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be an array or null.")
     });
   });
   it('Array - wrong type - enforce_type: "none"', function(){
@@ -2317,7 +2318,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field][0] must be a finite number.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field][0] must be a finite number.")
     });
   });
   it('Array - wrong type inside - enforce_type: "loose"', function(){
@@ -2337,7 +2338,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field][0] must be a finite number or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field][0] must be a finite number or null.")
     });
   });
   it('Array - wrong type inside - enforce_type: "none"', function(){
@@ -2373,7 +2374,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field][3] must be a finite number.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field][3] must be a finite number.")
     });
   });
   it('Array - wrong type inside - not first - enforce_type: "strict" - 2', function(){
@@ -2393,7 +2394,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "The element in the array [field] (position 3) cannot be `undefined`.")
+      return (error instanceof Errors.ValidationError) && (error.message === "The element in the array [field] (position 3) cannot be `undefined`.")
     });
   });
   it('Array - wrong type inside - not first - enforce_type: "loose"', function(){
@@ -2413,7 +2414,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "The element in the array [field] (position 3) cannot be `undefined`.")
+      return (error instanceof Errors.ValidationError) && (error.message === "The element in the array [field] (position 3) cannot be `undefined`.")
     });
 
 
@@ -2450,7 +2451,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be defined.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be defined.")
     });
   });
   it('Object - undefined - enforce_missing: false', function(){
@@ -2485,7 +2486,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be an object or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be an object or null.")
     });
   });
   it('Object - undefined - enforce_type: "none"', function(){
@@ -2537,7 +2538,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be an object.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be an object.")
     });
   });
   it('Object - nested wrong type - enforce_type: "strict"', function(){
@@ -2559,7 +2560,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be an object.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be an object.")
     });
   });
   it('Object - nested wrong type - enforce_type: "strict" - 2', function(){
@@ -2583,7 +2584,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field][foo] must be a finite number.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field][foo] must be a finite number.")
     });
   });
   it('Object - nested wrong type - enforce_type: "loose"', function(){
@@ -2607,7 +2608,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field][foo] must be a finite number or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field][foo] must be a finite number or null.")
     });
   });
   it('Object - Empty - enforce_type: "strict"', function(){
@@ -2642,7 +2643,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field][foo] must be defined.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field][foo] must be defined.")
     });
   });
   it('Object - undefined - enforce_type: "loose"', function(){
@@ -2682,7 +2683,7 @@ describe('validate', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field][foo] must be a finite number or null.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field][foo] must be a finite number or null.")
     });
   });
   it('Object - nested wrong type 5 - enforce_type: "none"', function(){
@@ -2855,7 +2856,7 @@ describe('validate', function(){
       })
 
     }, function(error) {
-      return (error instanceof Error) && (error.message === "Value for [field] must be a string.")
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [field] must be a string.")
     });
   });
 });
@@ -3202,7 +3203,7 @@ describe('_validator', function(){
       foreignKey: String
     }, {init: false, validator: function() {
         if (this.id !== this.field) {
-          throw new Error("Expecting `id` value to be `field` value.")
+          throw new Errors.ValidationError("Expecting `id` value to be `field` value.")
         }
       }
     })
@@ -3217,7 +3218,7 @@ describe('_validator', function(){
       foreignKey: String
     }, {init: false, validator: function() {
         if (this.id !== this.field) {
-          throw new Error("Expecting `id` value to be `field` value.")
+          throw new Errors.ValidationError("Expecting `id` value to be `field` value.")
         }
       }
     })
@@ -3236,7 +3237,7 @@ describe('_validator', function(){
       field: String
     }, {validator: function() {
       if (this.otherDoc == null) {
-        throw new Error("Relation must be defined.")
+        throw new Errors.ValidationError("Relation must be defined.")
       }
     }})
     var doc = new Model({id: "abc", field: "abc"});
@@ -3245,7 +3246,7 @@ describe('_validator', function(){
       assert.throws(function() {
         doc.validate();
       }, function(error) {
-        return (error instanceof Error) && (error.message === "Relation must be defined.")
+        return (error instanceof Errors.ValidationError) && (error.message === "Relation must be defined.")
       });
 
       Model.hasOne(Model, 'otherDoc', 'id', 'foreignKey');
@@ -3293,7 +3294,7 @@ describe('_validator', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error)
+      return (error instanceof Errors.ValidationError)
         && (error.message === "Document's validator returned `false`.")
     });
   });
@@ -3303,7 +3304,7 @@ describe('_validator', function(){
       field: {_type: String}
     }, {init: false, validator: function() {
         if (this.id !== this.field) {
-          throw new Error("Expecting `id` value to be `field` value.")
+          throw new Errors.ValidationError("Expecting `id` value to be `field` value.")
         }
       }
     })
@@ -3312,7 +3313,7 @@ describe('_validator', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error)
+      return (error instanceof Errors.ValidationError)
         && (error.message === "Expecting `id` value to be `field` value.")
     });
   });
@@ -3329,7 +3330,7 @@ describe('_validator', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error)
+      return (error instanceof Errors.ValidationError)
         && (error.message === "Document's validator returned `false`.")
     });
   });
@@ -3339,7 +3340,7 @@ describe('_validator', function(){
       field: {_type: String}
     }, {init: false, validator: function() {
         if (this.id !== this.nested.field) {
-          throw new Error("Expecting `id` value to be `field` value.")
+          throw new Errors.ValidationError("Expecting `id` value to be `field` value.")
         }
       }
     })
@@ -3353,7 +3354,7 @@ describe('_validator', function(){
       field: {_type: String}
     }, {init: false, validator: function() {
         if (this.id !== this.nested.field) {
-          throw new Error("Expecting `field` value to be `field` value.")
+          throw new Errors.ValidationError("Expecting `field` value to be `field` value.")
         }
       }
     })
@@ -3362,7 +3363,7 @@ describe('_validator', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error)
+      return (error instanceof Errors.ValidationError)
         && (error.message === "Expecting `field` value to be `field` value.")
     });
   });
@@ -3371,7 +3372,7 @@ describe('_validator', function(){
       id: String,
       field: {_type: String, validator: function(value) {
         if (value !== "abc") {
-          throw new Error("Expecting `field` value to be 'abc'.")
+          throw new Errors.ValidationError("Expecting `field` value to be 'abc'.")
         }
       }}
     }, {init: false})
@@ -3383,7 +3384,7 @@ describe('_validator', function(){
       id: String,
       field: {_type: String, validator: function(value) {
         if (value !== "abc") {
-          throw new Error("Expecting `field` value to be 'abc'.")
+          throw new Errors.ValidationError("Expecting `field` value to be 'abc'.")
         }
       }}
     }, {init: false})
@@ -3391,7 +3392,7 @@ describe('_validator', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error)
+      return (error instanceof Errors.ValidationError)
         && (error.message === "Expecting `field` value to be 'abc'.")
     });
   });
@@ -3406,7 +3407,7 @@ describe('_validator', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error)
+      return (error instanceof Errors.ValidationError)
         && (error.message === "Validator for the field [field] returned `false`.")
     });
   });
@@ -3421,7 +3422,7 @@ describe('_validator', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error)
+      return (error instanceof Errors.ValidationError)
         && (error.message === "Validator for the field [field] returned `false`.")
     });
   });
@@ -3431,7 +3432,7 @@ describe('_validator', function(){
       nested: {
         field: {_type: String, validator: function(value) {
           if (value !== "abc") {
-            throw new Error("Expecting `field` value to be 'abc'.")
+            throw new Errors.ValidationError("Expecting `field` value to be 'abc'.")
           }
         }
       }}
@@ -3447,7 +3448,7 @@ describe('_validator', function(){
       nested: {
         field: {_type: String, validator: function(value) {
           if (value !== "abc") {
-            throw new Error("Expecting `field` value to be 'abc'.")
+            throw new Errors.ValidationError("Expecting `field` value to be 'abc'.")
           }
         }
       }}
@@ -3457,7 +3458,7 @@ describe('_validator', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error)
+      return (error instanceof Errors.ValidationError)
         && (error.message === "Expecting `field` value to be 'abc'.")
     });
   });
@@ -3480,7 +3481,7 @@ describe('_validator', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error)
+      return (error instanceof Errors.ValidationError)
         && (error.message === "Value for [arr][1] must be a finite number or null.")
     });
   });
@@ -3503,7 +3504,7 @@ describe('_validator', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error)
+      return (error instanceof Errors.ValidationError)
         && (error.message === "Value for [ob][foo] must be a string or null.")
     });
   });
@@ -3540,7 +3541,7 @@ describe('_validator', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error)
+      return (error instanceof Errors.ValidationError)
         && (error.message === "The field [field] must be one of these values: foo, bar, buzz.")
     });
   });
@@ -3553,7 +3554,7 @@ describe('_validator', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error)
+      return (error instanceof Errors.ValidationError)
         && (error.message === "The field [field] must be one of these values: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10.")
     });
   });
@@ -3566,7 +3567,7 @@ describe('_validator', function(){
     assert.throws(function() {
       doc.validate();
     }, function(error) {
-      return (error instanceof Error)
+      return (error instanceof Errors.ValidationError)
         && (error.message === "The field [field] must be one of these values: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10...")
     });
   });


### PR DESCRIPTION
It would be helpful to have a new error type for validation errors, similar to the ```DocumentNotFound``` error type defined in https://github.com/neumino/thinky/blob/master/lib/errors.js

The use case I am imagining is for HTTP status code responses in a RESTful API. You could more granularly report to the API consumer whether an error was their fault due to submission of bad data which the thinky model rejects (400), a particular document not being found (404 - which the ```DocumentNotFound``` type is already helpful for), or some other failure (500). 

I believe this new error could be thrown instead of the more generic Error type in https://github.com/neumino/thinky/blob/master/lib/schema.js

If you think this makes sense, I would be happy to try my hand at a pull request for this.

Thanks!