### PR TITLE
Fix embeded chainables

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -240,7 +240,7 @@ function parse(schema, prefix, options, model) {
     }
 
     if (schema.length > 0) {
-      result.schema(parse(schema[0]), prefix+"[0]", options);
+      result.schema(parse(schema[0], prefix+"[0]", options));
     }
     return result;
 

--- a/test/schema.js
+++ b/test/schema.js
@@ -161,6 +161,13 @@ describe('schema', function(){
 describe('Chainable types', function(){
   // Chainable types were added in 1.15.3, prior tests still validates options and such.
   // These tests are mostly for new validators like `min`/`max`/`alphanum`/etc.
+  it('General - chainable types in nested schemas', function(){
+    var name = util.s8();
+    var Model = thinky.createModel(name, 
+     {id: type.string(),
+      objectArray: [{ myAttribute: thinky.type.object() }]})
+    var doc = new Model({ id: util.s8(), objectArray : {} })
+  });
   it('String - basic - valid string', function(){
     var name = util.s8();
     var Model = thinky.createModel(name,


### PR DESCRIPTION
A recent Thinky update broke chainable types inside of a nested object array.
Here is an example of a schema that is currently broken:

```javascript
var thinky = require('thinky')();
var Model = thinky.createModel('Model', {
  id : String,
  objectArray : [{
    myAttribute : thinky.type.object()
  }]
});
```

That throws:

```
TypeError: Cannot read property 'enforce_missing' of undefined
    at parse (/.../thinky/lib/schema.js:218:123)
    at /.../thinky/lib/schema.js:228:28
    at Object.loopKeys (/.../thinky/lib/util.js:203:16)
    at parse (/.../thinky/lib/schema.js:227:12)
    at parse (/.../thinky/lib/schema.js:243:21)
    at /.../thinky/lib/schema.js:228:28
    at Object.loopKeys (/.../thinky/lib/util.js:203:16)
    at Object.parse (/.../thinky/lib/schema.js:227:12)
    at new Model (/.../thinky/lib/model.js:34:29)
    at Function.Model.new (/.../thinky/lib/model.js:95:15)
```

This was the result of a typo that accidentally passed `options` as `undefined` to the `parse` function. Later on, this would result in an exception when `options.enforce_missing` was accessed. I'm sure there are other schema structures that would trigger this exception, but this fix should correct all of them.

I added a test, but not sure if it's in the right place or follows project guidelines. Let me know if it needs revision!