### PR TITLE
Refactoring and cleanup of Query's _execute() function

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -210,24 +210,32 @@ Query.prototype._execute = function(options, parse, callback) {
               }
             }
           })
+          return;
         }
-        else if ((result != null) && (typeof result.getType === 'function') &&
-            ((result.getType() === 'Feed') ||
-            (result.getType() === 'OrderByLimitFeed') ||
-            (result.getType() === 'UnionedFeed'))) {
-          var feed = new Feed(result, self._model);
-          resolve(feed);
+
+        if (result != null && typeof result.getType === 'function') {
+          var resultType = result.getType();
+          if (resultType === 'Feed' ||
+            resultType === 'OrderByLimitFeed' ||
+            resultType === 'UnionedFeed'
+          ) {
+            var feed = new Feed(result, self._model);
+            resolve(feed);
+            return;
+          }
+
+          if (resultType === 'AtomFeed') {
+            result.next().then(function(initial) {
+              var value = initial.new_val || {};
+              self._model._parse(value).then(function(doc) {
+                doc._setFeed(result);
+                resolve(doc);
+              }).error(reject);
+            });
+            return;
+          }
         }
-        else if ((result != null) && (typeof result.getType === 'function') && (result.getType() === 'AtomFeed')) {
-          result.next().then(function(initial) {
-            var value = initial.new_val || {};
-            self._model._parse(value).then(function(doc) {
-              doc._setFeed(result);
-              resolve(doc);
-            }).error(reject);
-          });
-        }
-        else {
+
           if (parse === true) {
             if (result === null) {
               reject(new Errors.DocumentNotFound())
@@ -244,7 +252,6 @@ Query.prototype._execute = function(options, parse, callback) {
               resolve(result);
             }
           }
-        }
       }).error(function(err) {
         if (err.message.match(/^The query did not find a document and returned null./)) {
           //Reject with an instance of Errors.DocumentNotFound

--- a/lib/query.js
+++ b/lib/query.js
@@ -130,9 +130,6 @@ Query.prototype._execute = function(options, parse, callback) {
             }
             return;
           }
-          else if (!Array.isArray(result.changes)) {
-            reject(new Errors.InvalidWrite("Field `changes` of a write query not found."));
-          }
 
           var promises = [];
           var foundInvalidDocument = false;

--- a/lib/query.js
+++ b/lib/query.js
@@ -137,7 +137,6 @@ Query.prototype._executeCallback = function(fullOptions, parse, groupFormat) {
 
     // Expect a write result from RethinkDB
     if (self._postValidation === true) {
-      var error = null;
       if (result.errors > 0) {
         throw new Errors.InvalidWrite("An error occured during the write", result);
       }

--- a/lib/query.js
+++ b/lib/query.js
@@ -126,149 +126,150 @@ Query.prototype._execute = function(options, parse, callback) {
 
 Query.prototype._executeCallback = function(fullOptions, parse, groupFormat) {
   var self = this;
-      if (self._error !== undefined) {
-        return Promise.reject(new Error("The partial value is not valid, so the write was not executed. The original error was:\n"+self._error.message));
+  if (self._error !== undefined) {
+    return Promise.reject(new Error("The partial value is not valid, so the write was not executed. The original error was:\n"+self._error.message));
+  }
+
+  return self._query.run(fullOptions).then(function(result) {
+    if (result === null && parse) {
+      throw new Errors.DocumentNotFound();
+    }
+
+    // Expect a write result from RethinkDB
+    if (self._postValidation === true) {
+      var error = null;
+      if (result.errors > 0) {
+        throw new Errors.InvalidWrite("An error occured during the write", result);
       }
-      return self._query.run(fullOptions).then(function(result) {
-        if (result === null && parse) {
-          throw new Errors.DocumentNotFound();
+      if (!Array.isArray(result.changes)) {
+        if (self._isPointWrite()) {
+          return;
         }
-
-        // Expect a write result from RethinkDB
-        if (self._postValidation === true) {
-          var error = null;
-          if (result.errors > 0) {
-            throw new Errors.InvalidWrite("An error occured during the write", result);
-          }
-          if (!Array.isArray(result.changes)) {
-            if (self._isPointWrite()) {
-              return;
-            }
-            else {
-              return [];
-            }
-            return;
-          }
-
-          var promises = [];
-          for(var i=0; i<result.changes.length; i++) {
-            (function(i) {
-              if (result.changes[i].new_val !== null) {
-                promises.push(self._model._parse(result.changes[i].new_val));
-              }
-            })(i)
-          }
-          return Promise.all(promises).then(function(result) {
-            if (self._isPointWrite()) {
-              return result[0];
-            }
-            else if (result.length === 0) {
-              return [];
-            }
-            else {
-              return result;
-            }
-          }).error(function(error) {
-            if (error instanceof Errors.DocumentNotFound) {
-              // Should we send back null?
-            }
-            else {
-              var primaryKeyString = true; // whether all the primary keys are strings or not
-              var primaryKeys = [];
-              var keysToValues = {};
-              var r = self._model._thinky.r;
-              for(var p=0; p<result.changes.length; p++) {
-                // Extract the primary key of the document saved in the database
-                var primaryKey = util.extractPrimaryKey(
-                    result.changes[p].old_val,
-                    result.changes[p].new_val,
-                    self._model._pk)
-                if (primaryKey === undefined) {
-                  continue;
-                }
-
-                if (typeof primaryKey === "string") {
-                  keysToValues[primaryKey] = result.changes[p].old_val;
-                  primaryKeys.push(primaryKey);
-                }
-                else {
-                  primaryKeyString = false
-                  break;
-                }
-              }
-              if (primaryKeyString === true) {
-                r.table(self._model.getTableName()).getAll(r.args(primaryKeys)).replace(function(doc) {
-                  return r.expr(keysToValues)(doc(self._model._pk));
-                }).run().then(function(result) {
-                  throw new Errors.InvalidWrite("The write failed, and the changes were reverted");
-                }).error(function(error) {
-                  throw new Error("The write failed, and the attempt to revert the changes failed with the error:\n"+error.message);
-                });
-              }
-              else {
-                var revertPromises = [];
-                for(var p=0; p<result.changes.length; p++) {
-                  var primaryKey = util.extractPrimaryKey(
-                      result.changes[p].old_val,
-                      result.changes[p].new_val,
-                      self._model._pk)
-                  if (primaryKey === undefined) {
-                    continue;
-                  }
-
-                  revertPromises.push(r.table(self._model.getTableName())
-                    .get(primaryKey)
-                    .replace(result.changes[p].old_val)
-                    .run());
-                }
-                Promise.all(revertPromises).then(function(result) {
-                  reject(new Error("The write failed, and the changes were reverted."));
-                }).error(function(error) {
-                  reject(new Error("The write failed, and the attempt to revert the changes failed with the error:\n"+error.message));
-                });
-              }
-            }
-          })
+        else {
+          return [];
         }
+        return;
+      }
 
-        if (result != null && typeof result.getType === 'function') {
-          var resultType = result.getType();
-          if (resultType === 'Feed' ||
-            resultType === 'OrderByLimitFeed' ||
-            resultType === 'UnionedFeed'
-          ) {
-            var feed = new Feed(result, self._model);
-            return feed;
+      var promises = [];
+      for(var i=0; i<result.changes.length; i++) {
+        (function(i) {
+          if (result.changes[i].new_val !== null) {
+            promises.push(self._model._parse(result.changes[i].new_val));
           }
+        })(i)
+      }
+      return Promise.all(promises).then(function(result) {
+        if (self._isPointWrite()) {
+          return result[0];
+        }
+        else if (result.length === 0) {
+          return [];
+        }
+        else {
+          return result;
+        }
+      }).error(function(error) {
+        if (error instanceof Errors.DocumentNotFound) {
+          // Should we send back null?
+        }
+        else {
+          var primaryKeyString = true; // whether all the primary keys are strings or not
+          var primaryKeys = [];
+          var keysToValues = {};
+          var r = self._model._thinky.r;
+          for(var p=0; p<result.changes.length; p++) {
+            // Extract the primary key of the document saved in the database
+            var primaryKey = util.extractPrimaryKey(
+                result.changes[p].old_val,
+                result.changes[p].new_val,
+                self._model._pk)
+            if (primaryKey === undefined) {
+              continue;
+            }
 
-          if (resultType === 'AtomFeed') {
-            return result.next().then(function(initial) {
-              var value = initial.new_val || {};
-              return self._model._parse(value).then(function(doc) {
-                doc._setFeed(result);
-                return doc;
-              });
+            if (typeof primaryKey === "string") {
+              keysToValues[primaryKey] = result.changes[p].old_val;
+              primaryKeys.push(primaryKey);
+            }
+            else {
+              primaryKeyString = false
+              break;
+            }
+          }
+          if (primaryKeyString === true) {
+            r.table(self._model.getTableName()).getAll(r.args(primaryKeys)).replace(function(doc) {
+              return r.expr(keysToValues)(doc(self._model._pk));
+            }).run().then(function(result) {
+              reject(new Errors.InvalidWrite("The write failed, and the changes were reverted"));
+            }).error(function(error) {
+              reject(new Error("The write failed, and the attempt to revert the changes failed with the error:\n"+error.message));
+            });
+          }
+          else {
+            var revertPromises = [];
+            for(var p=0; p<result.changes.length; p++) {
+              var primaryKey = util.extractPrimaryKey(
+                  result.changes[p].old_val,
+                  result.changes[p].new_val,
+                  self._model._pk)
+              if (primaryKey === undefined) {
+                continue;
+              }
+
+              revertPromises.push(r.table(self._model.getTableName())
+                .get(primaryKey)
+                .replace(result.changes[p].old_val)
+                .run());
+            }
+            Promise.all(revertPromises).then(function(result) {
+              reject(new Error("The write failed, and the changes were reverted."));
+            }).error(function(error) {
+              reject(new Error("The write failed, and the attempt to revert the changes failed with the error:\n"+error.message));
             });
           }
         }
-
-        if (parse === true) {
-          return self._model._parse(result);
-        }
-
-        if (groupFormat !== 'raw') {
-          return Query.prototype._convertGroupedData(result);
-        }
-
-        return result;
-      }).catch(function(err) {
-        if (err.message.match(/^The query did not find a document and returned null./)) {
-          //Reject with an instance of Errors.DocumentNotFound
-          err = new Errors.DocumentNotFound(err.message);
-        }
-        return Promise.reject(err);
       })
-    };
+    }
+
+    if (result != null && typeof result.getType === 'function') {
+      var resultType = result.getType();
+      if (resultType === 'Feed' ||
+        resultType === 'OrderByLimitFeed' ||
+        resultType === 'UnionedFeed'
+      ) {
+        var feed = new Feed(result, self._model);
+        return feed;
+      }
+
+      if (resultType === 'AtomFeed') {
+        return result.next().then(function(initial) {
+          var value = initial.new_val || {};
+          return self._model._parse(value).then(function(doc) {
+            doc._setFeed(result);
+            return doc;
+          });
+        });
+      }
+    }
+
+    if (parse === true) {
+      return self._model._parse(result);
+    }
+
+    if (groupFormat !== 'raw') {
+      return Query.prototype._convertGroupedData(result);
+    }
+
+    return result;
+  }).catch(function(err) {
+      if (err.message.match(/^The query did not find a document and returned null./)) {
+        //Reject with an instance of Errors.DocumentNotFound
+        err = new Errors.DocumentNotFound(err.message);
+      }
+      return Promise.reject(err);
+  })
+};
 
 
 /**

--- a/lib/query.js
+++ b/lib/query.js
@@ -145,10 +145,7 @@ Query.prototype._executeCallback = function(fullOptions, parse, groupFormat) {
         if (self._isPointWrite()) {
           return;
         }
-        else {
-          return [];
-        }
-        return;
+        return [];
       }
 
       var promises = [];
@@ -163,12 +160,7 @@ Query.prototype._executeCallback = function(fullOptions, parse, groupFormat) {
         if (self._isPointWrite()) {
           return result[0];
         }
-        else if (result.length === 0) {
-          return [];
-        }
-        else {
-          return result;
-        }
+        return result;
       }).error(function(error) {
         if (error instanceof Errors.DocumentNotFound) {
           // Should we send back null?
@@ -263,11 +255,11 @@ Query.prototype._executeCallback = function(fullOptions, parse, groupFormat) {
 
     return result;
   }).catch(function(err) {
-      if (err.message.match(/^The query did not find a document and returned null./)) {
-        //Reject with an instance of Errors.DocumentNotFound
-        err = new Errors.DocumentNotFound(err.message);
-      }
-      return Promise.reject(err);
+    if (err.message.match(/^The query did not find a document and returned null./)) {
+      //Reject with an instance of Errors.DocumentNotFound
+      err = new Errors.DocumentNotFound(err.message);
+    }
+    return Promise.reject(err);
   })
 };
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -207,7 +207,7 @@ Query.prototype._validateQueryResult = function(result) {
       // Should we send back null?
     }
     else {
-      var primaryKeyString = true; // whether all the primary keys are strings or not
+      var revertPromises = [];
       var primaryKeys = [];
       var keysToValues = {};
       var r = self._model._thinky.r;
@@ -226,41 +226,30 @@ Query.prototype._validateQueryResult = function(result) {
           primaryKeys.push(primaryKey);
         }
         else {
-          primaryKeyString = false
-          break;
-        }
-      }
-      if (primaryKeyString === true) {
-        return r.table(self._model.getTableName()).getAll(r.args(primaryKeys)).replace(function(doc) {
-          return r.expr(keysToValues)(doc(self._model._pk));
-        }).run().then(function(result) {
-          throw new Errors.InvalidWrite("The write failed, and the changes were reverted");
-        }).error(function(error) {
-          throw new Error("The write failed, and the attempt to revert the changes failed with the error:\n"+error.message);
-        });
-      }
-      else {
-        var revertPromises = [];
-        for(var p=0; p<result.changes.length; p++) {
-          var primaryKey = util.extractPrimaryKey(
-              result.changes[p].old_val,
-              result.changes[p].new_val,
-              self._model._pk)
-          if (primaryKey === undefined) {
-            continue;
-          }
-
+          // Replace documents with non-string type primary keys
+          // one by one.
           revertPromises.push(r.table(self._model.getTableName())
             .get(primaryKey)
             .replace(result.changes[p].old_val)
             .run());
         }
-        return Promise.all(revertPromises).then(function(result) {
-          throw new Error("The write failed, and the changes were reverted.");
-        }).error(function(error) {
-          throw new Error("The write failed, and the attempt to revert the changes failed with the error:\n"+error.message);
-        });
       }
+
+      // Replace all documents with string-type primary keys
+      // in a single replace() operation.
+      if (primaryKeys.length) {
+        revertPromises.push(
+          r.table(self._model.getTableName()).getAll(r.args(primaryKeys)).replace(function(doc) {
+            return r.expr(keysToValues)(doc(self._model._pk));
+          }).run()
+        );
+      }
+
+      return Promise.all(revertPromises).then(function(result) {
+        throw new Error("The write failed, and the changes were reverted.");
+      }).error(function(error) {
+        throw new Error("The write failed, and the attempt to revert the changes failed with the error:\n"+error.message);
+      });
     }
   })
 };

--- a/lib/query.js
+++ b/lib/query.js
@@ -115,6 +115,11 @@ Query.prototype._execute = function(options, parse, callback) {
         return reject(new Error("The partial value is not valid, so the write was not executed. The original error was:\n"+self._error.message));
       }
       self._query.run(fullOptions).then(function(result) {
+        if (result === null && parse) {
+          reject(new Errors.DocumentNotFound());
+          return;
+        }
+
         // Expect a write result from RethinkDB
         if (self._postValidation === true) {
           var error = null;
@@ -237,12 +242,7 @@ Query.prototype._execute = function(options, parse, callback) {
         }
 
         if (parse === true) {
-          if (result === null) {
-            reject(new Errors.DocumentNotFound())
-          }
-          else {
-            self._model._parse(result).then(resolve).error(reject);
-          }
+          self._model._parse(result).then(resolve).error(reject);
         }
         else {
           if (options.groupFormat !== 'raw') {

--- a/lib/query.js
+++ b/lib/query.js
@@ -236,22 +236,22 @@ Query.prototype._execute = function(options, parse, callback) {
           }
         }
 
-          if (parse === true) {
-            if (result === null) {
-              reject(new Errors.DocumentNotFound())
-            }
-            else {
-              self._model._parse(result).then(resolve).error(reject);
-            }
+        if (parse === true) {
+          if (result === null) {
+            reject(new Errors.DocumentNotFound())
           }
           else {
-            if (options.groupFormat !== 'raw') {
-              resolve(Query.prototype._convertGroupedData(result));
-            }
-            else {
-              resolve(result);
-            }
+            self._model._parse(result).then(resolve).error(reject);
           }
+        }
+        else {
+          if (options.groupFormat !== 'raw') {
+            resolve(Query.prototype._convertGroupedData(result));
+          }
+          else {
+            resolve(result);
+          }
+        }
       }).error(function(err) {
         if (err.message.match(/^The query did not find a document and returned null./)) {
           //Reject with an instance of Errors.DocumentNotFound

--- a/lib/query.js
+++ b/lib/query.js
@@ -132,7 +132,6 @@ Query.prototype._execute = function(options, parse, callback) {
           }
 
           var promises = [];
-          var foundInvalidDocument = false;
           for(var i=0; i<result.changes.length; i++) {
             (function(i) {
               if (result.changes[i].new_val !== null) {
@@ -151,7 +150,6 @@ Query.prototype._execute = function(options, parse, callback) {
               resolve(result)
             }
           }).error(function(error) {
-            foundInvalidDocument = true;
             if (error instanceof Errors.DocumentNotFound) {
               // Should we send back null?
             }

--- a/lib/query.js
+++ b/lib/query.js
@@ -110,28 +110,42 @@ Query.prototype._execute = function(options, parse, callback) {
     })
   }
   else {
-    var executeCallback = function(resolve, reject) {
+    if (self._model._getModel()._tableReady === true) {
+      p = self._executeCallback(fullOptions, parse, options.groupFormat);
+    }
+    else {
+      p = new Promise(function(resolve, reject) {
+        self._model._onTableReady.push(function() {
+          return self._executeCallback(fullOptions, options.groupFormat);
+        });
+      });
+    }
+  }
+  return p.nodeify(callback);
+}
+
+Query.prototype._executeCallback = function(fullOptions, parse, groupFormat) {
+  var self = this;
       if (self._error !== undefined) {
-        return reject(new Error("The partial value is not valid, so the write was not executed. The original error was:\n"+self._error.message));
+        return Promise.reject(new Error("The partial value is not valid, so the write was not executed. The original error was:\n"+self._error.message));
       }
-      self._query.run(fullOptions).then(function(result) {
+      return self._query.run(fullOptions).then(function(result) {
         if (result === null && parse) {
-          reject(new Errors.DocumentNotFound());
-          return;
+          throw new Errors.DocumentNotFound();
         }
 
         // Expect a write result from RethinkDB
         if (self._postValidation === true) {
           var error = null;
           if (result.errors > 0) {
-            return reject(new Errors.InvalidWrite("An error occured during the write", result));
+            throw new Errors.InvalidWrite("An error occured during the write", result);
           }
           if (!Array.isArray(result.changes)) {
             if (self._isPointWrite()) {
-              resolve();
+              return;
             }
             else {
-              resolve([]);
+              return [];
             }
             return;
           }
@@ -144,15 +158,15 @@ Query.prototype._execute = function(options, parse, callback) {
               }
             })(i)
           }
-          Promise.all(promises).then(function(result) {
+          return Promise.all(promises).then(function(result) {
             if (self._isPointWrite()) {
-              resolve(result[0]);
+              return result[0];
             }
             else if (result.length === 0) {
-              resolve([]);
+              return [];
             }
             else {
-              resolve(result)
+              return result;
             }
           }).error(function(error) {
             if (error instanceof Errors.DocumentNotFound) {
@@ -186,9 +200,9 @@ Query.prototype._execute = function(options, parse, callback) {
                 r.table(self._model.getTableName()).getAll(r.args(primaryKeys)).replace(function(doc) {
                   return r.expr(keysToValues)(doc(self._model._pk));
                 }).run().then(function(result) {
-                  reject(new Errors.InvalidWrite("The write failed, and the changes were reverted"));
+                  throw new Errors.InvalidWrite("The write failed, and the changes were reverted");
                 }).error(function(error) {
-                  reject(new Error("The write failed, and the attempt to revert the changes failed with the error:\n"+error.message));
+                  throw new Error("The write failed, and the attempt to revert the changes failed with the error:\n"+error.message);
                 });
               }
               else {
@@ -215,7 +229,6 @@ Query.prototype._execute = function(options, parse, callback) {
               }
             }
           })
-          return;
         }
 
         if (result != null && typeof result.getType === 'function') {
@@ -225,57 +238,37 @@ Query.prototype._execute = function(options, parse, callback) {
             resultType === 'UnionedFeed'
           ) {
             var feed = new Feed(result, self._model);
-            resolve(feed);
-            return;
+            return feed;
           }
 
           if (resultType === 'AtomFeed') {
-            result.next().then(function(initial) {
+            return result.next().then(function(initial) {
               var value = initial.new_val || {};
-              self._model._parse(value).then(function(doc) {
+              return self._model._parse(value).then(function(doc) {
                 doc._setFeed(result);
-                resolve(doc);
-              }).error(reject);
+                return doc;
+              });
             });
-            return;
           }
         }
 
         if (parse === true) {
-          self._model._parse(result).then(resolve).error(reject);
-          return;
+          return self._model._parse(result);
         }
 
-        if (options.groupFormat !== 'raw') {
-          resolve(Query.prototype._convertGroupedData(result));
-          return;
+        if (groupFormat !== 'raw') {
+          return Query.prototype._convertGroupedData(result);
         }
 
-        resolve(result);
-      }).error(function(err) {
+        return result;
+      }).catch(function(err) {
         if (err.message.match(/^The query did not find a document and returned null./)) {
           //Reject with an instance of Errors.DocumentNotFound
-          reject(new Errors.DocumentNotFound(err.message))
+          err = new Errors.DocumentNotFound(err.message);
         }
-        else {
-          reject(err)
-        }
+        return Promise.reject(err);
       })
     };
-
-    if (self._model._getModel()._tableReady === true) {
-      p = new Promise(executeCallback);
-    }
-    else {
-      p = new Promise(function(resolve, reject) {
-        self._model._onTableReady.push(function() {
-          executeCallback(resolve, reject);
-        });
-      });
-    }
-  }
-  return p.nodeify(callback);
-}
 
 
 /**

--- a/lib/query.js
+++ b/lib/query.js
@@ -168,7 +168,8 @@ Query.prototype._executeCallback = function(fullOptions, parse, groupFormat) {
 
     return result;
   }).catch(function(err) {
-    if (err.message.match(/^The query did not find a document and returned null./)) {
+    var notFoundRegex = new RegExp('^' + new Errors.DocumentNotFound().message);
+    if (err.message.match(notFoundRegex)) {
       //Reject with an instance of Errors.DocumentNotFound
       err = new Errors.DocumentNotFound(err.message);
     }
@@ -519,7 +520,7 @@ Query.prototype.removeRelations = function(relationsToRemove) {
         // The driver currently just returns `null`.
         (function(key) {
           Query.prototype[key] = function() {
-            return new Query(this._model, this._query[key].apply(this._query, arguments)).default(this._r.error("The query did not find a document and returned null."));
+            return new Query(this._model, this._query[key].apply(this._query, arguments)).default(this._r.error(new Errors.DocumentNotFound().message));
           }
         })(key);
       }

--- a/lib/query.js
+++ b/lib/query.js
@@ -36,7 +36,7 @@ function Query(model, query, postValidation, error) {
   }
 
   if (postValidation) {
-    this._postValidation = (postValidation === true) ? true: false;
+    this._postValidation = postValidation === true;
   }
   if (error) {
     // Note `Query.prototype.error` is defined because of `r.error`, so we shouldn't

--- a/lib/query.js
+++ b/lib/query.js
@@ -137,90 +137,7 @@ Query.prototype._executeCallback = function(fullOptions, parse, groupFormat) {
 
     // Expect a write result from RethinkDB
     if (self._postValidation === true) {
-      if (result.errors > 0) {
-        throw new Errors.InvalidWrite("An error occured during the write", result);
-      }
-      if (!Array.isArray(result.changes)) {
-        if (self._isPointWrite()) {
-          return;
-        }
-        return [];
-      }
-
-      var promises = [];
-      for(var i=0; i<result.changes.length; i++) {
-        (function(i) {
-          if (result.changes[i].new_val !== null) {
-            promises.push(self._model._parse(result.changes[i].new_val));
-          }
-        })(i)
-      }
-      return Promise.all(promises).then(function(result) {
-        if (self._isPointWrite()) {
-          return result[0];
-        }
-        return result;
-      }).error(function(error) {
-        if (error instanceof Errors.DocumentNotFound) {
-          // Should we send back null?
-        }
-        else {
-          var primaryKeyString = true; // whether all the primary keys are strings or not
-          var primaryKeys = [];
-          var keysToValues = {};
-          var r = self._model._thinky.r;
-          for(var p=0; p<result.changes.length; p++) {
-            // Extract the primary key of the document saved in the database
-            var primaryKey = util.extractPrimaryKey(
-                result.changes[p].old_val,
-                result.changes[p].new_val,
-                self._model._pk)
-            if (primaryKey === undefined) {
-              continue;
-            }
-
-            if (typeof primaryKey === "string") {
-              keysToValues[primaryKey] = result.changes[p].old_val;
-              primaryKeys.push(primaryKey);
-            }
-            else {
-              primaryKeyString = false
-              break;
-            }
-          }
-          if (primaryKeyString === true) {
-            r.table(self._model.getTableName()).getAll(r.args(primaryKeys)).replace(function(doc) {
-              return r.expr(keysToValues)(doc(self._model._pk));
-            }).run().then(function(result) {
-              reject(new Errors.InvalidWrite("The write failed, and the changes were reverted"));
-            }).error(function(error) {
-              reject(new Error("The write failed, and the attempt to revert the changes failed with the error:\n"+error.message));
-            });
-          }
-          else {
-            var revertPromises = [];
-            for(var p=0; p<result.changes.length; p++) {
-              var primaryKey = util.extractPrimaryKey(
-                  result.changes[p].old_val,
-                  result.changes[p].new_val,
-                  self._model._pk)
-              if (primaryKey === undefined) {
-                continue;
-              }
-
-              revertPromises.push(r.table(self._model.getTableName())
-                .get(primaryKey)
-                .replace(result.changes[p].old_val)
-                .run());
-            }
-            Promise.all(revertPromises).then(function(result) {
-              reject(new Error("The write failed, and the changes were reverted."));
-            }).error(function(error) {
-              reject(new Error("The write failed, and the attempt to revert the changes failed with the error:\n"+error.message));
-            });
-          }
-        }
-      })
+      return self._validateQueryResult(result);
     }
 
     if (result != null && typeof result.getType === 'function') {
@@ -259,6 +176,95 @@ Query.prototype._executeCallback = function(fullOptions, parse, groupFormat) {
       err = new Errors.DocumentNotFound(err.message);
     }
     return Promise.reject(err);
+  })
+};
+
+
+Query.prototype._validateQueryResult = function(result) {
+  var self = this;
+  if (result.errors > 0) {
+    return Promise.reject(new Errors.InvalidWrite("An error occured during the write", result));
+  }
+  if (!Array.isArray(result.changes)) {
+    if (self._isPointWrite()) {
+      return Promise.resolve();
+    }
+    return Promise.resolve([]);
+  }
+
+  var promises = [];
+  for(var i=0; i<result.changes.length; i++) {
+    (function(i) {
+      if (result.changes[i].new_val !== null) {
+        promises.push(self._model._parse(result.changes[i].new_val));
+      }
+    })(i)
+  }
+  return Promise.all(promises).then(function(result) {
+    if (self._isPointWrite()) {
+      return result[0];
+    }
+    return result;
+  }).error(function(error) {
+    if (error instanceof Errors.DocumentNotFound) {
+      // Should we send back null?
+    }
+    else {
+      var primaryKeyString = true; // whether all the primary keys are strings or not
+      var primaryKeys = [];
+      var keysToValues = {};
+      var r = self._model._thinky.r;
+      for(var p=0; p<result.changes.length; p++) {
+        // Extract the primary key of the document saved in the database
+        var primaryKey = util.extractPrimaryKey(
+            result.changes[p].old_val,
+            result.changes[p].new_val,
+            self._model._pk)
+        if (primaryKey === undefined) {
+          continue;
+        }
+
+        if (typeof primaryKey === "string") {
+          keysToValues[primaryKey] = result.changes[p].old_val;
+          primaryKeys.push(primaryKey);
+        }
+        else {
+          primaryKeyString = false
+          break;
+        }
+      }
+      if (primaryKeyString === true) {
+        return r.table(self._model.getTableName()).getAll(r.args(primaryKeys)).replace(function(doc) {
+          return r.expr(keysToValues)(doc(self._model._pk));
+        }).run().then(function(result) {
+          throw new Errors.InvalidWrite("The write failed, and the changes were reverted");
+        }).error(function(error) {
+          throw new Error("The write failed, and the attempt to revert the changes failed with the error:\n"+error.message);
+        });
+      }
+      else {
+        var revertPromises = [];
+        for(var p=0; p<result.changes.length; p++) {
+          var primaryKey = util.extractPrimaryKey(
+              result.changes[p].old_val,
+              result.changes[p].new_val,
+              self._model._pk)
+          if (primaryKey === undefined) {
+            continue;
+          }
+
+          revertPromises.push(r.table(self._model.getTableName())
+            .get(primaryKey)
+            .replace(result.changes[p].old_val)
+            .run());
+        }
+        return Promise.all(revertPromises).then(function(result) {
+          throw new Error("The write failed, and the changes were reverted.");
+        }).error(function(error) {
+          throw new Error("The write failed, and the attempt to revert the changes failed with the error:\n"+error.message);
+        });
+      }
+    }
   })
 };
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -57,11 +57,10 @@ function Query(model, query, postValidation, error) {
  */
 Query.prototype.run = function(options, callback) {
   if (typeof options === 'function') {
-    return this._execute({}, true, options);
+    callback = options;
+    options = {};
   }
-  else {
-    return this._execute(options, true, callback);
-  }
+  return this._execute(options, true).nodeify(callback);
 }
 
 
@@ -73,13 +72,11 @@ Query.prototype.run = function(options, callback) {
  * of the query.
  */
 Query.prototype.execute = function(options, callback) {
-
   if (typeof options === 'function') {
-    return this._execute({}, false, options);
+    callback = options;
+    options = {};
   }
-  else {
-    return this._execute(options, false, callback);
-  }
+  return this._execute(options, false).nodeify(callback);
 }
 
 
@@ -92,7 +89,7 @@ Query.prototype.execute = function(options, callback) {
  * of the query.
  * @private
  */
-Query.prototype._execute = function(options, parse, callback) {
+Query.prototype._execute = function(options, parse) {
   var self = this;
   options = options || {};
   var fullOptions = {groupFormat: 'raw'}
@@ -103,25 +100,25 @@ Query.prototype._execute = function(options, parse, callback) {
     fullOptions.cursor = true;
   }
 
-  var p;
   if (self._model._error !== null) {
-    p = new Promise(function(resolve, reject) {
-      reject(self._model._error);
-    })
+    return Promise.reject(self._model._error);
   }
-  else {
-    if (self._model._getModel()._tableReady === true) {
-      p = self._executeCallback(fullOptions, parse, options.groupFormat);
-    }
-    else {
-      p = new Promise(function(resolve, reject) {
-        self._model._onTableReady.push(function() {
-          return self._executeCallback(fullOptions, options.groupFormat);
-        });
+
+  if (self._model._getModel()._tableReady === true) {
+    return self._executeCallback(fullOptions, parse, options.groupFormat);
+  }
+
+  return new Promise(function(resolve, reject) {
+    self._model._onTableReady.push(function() {
+      self._executeCallback(fullOptions, parse, options.groupFormat)
+      .then(function(result) {
+        resolve(result);
+      })
+      .catch(function(error) {
+        reject(error);
       });
-    }
-  }
-  return p.nodeify(callback);
+    });
+  });
 }
 
 Query.prototype._executeCallback = function(fullOptions, parse, groupFormat) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -243,15 +243,15 @@ Query.prototype._execute = function(options, parse, callback) {
 
         if (parse === true) {
           self._model._parse(result).then(resolve).error(reject);
+          return;
         }
-        else {
-          if (options.groupFormat !== 'raw') {
-            resolve(Query.prototype._convertGroupedData(result));
-          }
-          else {
-            resolve(result);
-          }
+
+        if (options.groupFormat !== 'raw') {
+          resolve(Query.prototype._convertGroupedData(result));
+          return;
         }
+
+        resolve(result);
       }).error(function(err) {
         if (err.message.match(/^The query did not find a document and returned null./)) {
           //Reject with an instance of Errors.DocumentNotFound

--- a/test/query.js
+++ b/test/query.js
@@ -12,6 +12,8 @@ modelNameSet[util.s8()] = true;
 modelNameSet[util.s8()] = true;
 var modelNames = Object.keys(modelNameSet);
 
+var documentNotFoundRegex = new RegExp('^' + new thinky.Errors.DocumentNotFound().message);
+
 var cleanTables = function(done) {
   var promises = [];
   var name;
@@ -147,7 +149,7 @@ describe('Model queries', function() {
     Model.get("NonExistingKey").merge({foo: "bar"}).run().then(function(result) {
       done(new Error("Was expecting an error"));
     }).error(function(error) {
-      assert(error.message.match(/^The query did not find a document and returned null./));
+      assert(error.message.match(documentNotFoundRegex));
       done();
     });
   });
@@ -870,7 +872,7 @@ describe('Query.run() should take options', function(){
     Model.get(0).run().then(function() {
       done(new Error("Was expecting an error"))
     }).catch(Errors.DocumentNotFound, function(err) {
-      assert(err.message.match(/^The query did not find a document and returned null./));
+      assert(err.message.match(documentNotFoundRegex));
       done();
     }).error(function() {
       done(new Error("Not the expected error"))
@@ -882,7 +884,7 @@ describe('Query.run() should take options', function(){
       done(new Error("Was expecting an error"))
     }).error(function(err) {
       assert(err instanceof Errors.DocumentNotFound);
-      assert(err.message.match(/^The query did not find a document and returned null./));
+      assert(err.message.match(documentNotFoundRegex));
       done();
     });
   });
@@ -1253,7 +1255,7 @@ describe('In place writes', function() {
       num: Number
     });
     Model.get('nonExistingId').update({foo: 'bar'}).run().error(function(error) {
-      assert(/The query did not find a document and returned null/.test(error.message));
+      assert(documentNotFoundRegex.test(error.message));
       done();
     });
   })


### PR DESCRIPTION
Here are some proposed changes whose purpose it is to improve readability on the rather complex _execute() function in query.js. There were some low hanging fruit in the form of redundant if/else statements and unused variables, however, most of the branch deals with breaking up the function into separate parts.

I'm fairly new to Thinky (and RethinkDB for that matter) so please forgive me if I've made any rookie mistakes.