### PR TITLE
refactor(errors): standardize errors and clean up definitions

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,39 +1,73 @@
+'use strict';
+
+var util = require('util');
+
+/**
+ * The base class for all thinky errors
+ *
+ * @constructor
+ * @alias Error
+ */
+function ThinkyError(message) {
+  this.name = 'ThinkyError';
+  this.message = message || 'ThinkyError';
+  Error.captureStackTrace && Error.captureStackTrace(this, this.constructor);
+};
+util.inherits(ThinkyError, Error);
+
 /**
  * DocumentNotFound error which is returned when `get` returns `null`.
  * "Extends" Error
  */
 function DocumentNotFound(message) {
-  Error.captureStackTrace(this, DocumentNotFound);
+  ThinkyError.call(this, message);
+  this.name = "DocumentNotFound";
   this.message = message || "The query did not find a document and returned null.";
 };
-DocumentNotFound.prototype = new Error();
-DocumentNotFound.prototype.name = "Document not found";
-module.exports.DocumentNotFound = DocumentNotFound;
-
+util.inherits(DocumentNotFound, ThinkyError);
 
 /**
  * InvalidWrite error which is returned when an inplace update/replace return
  * anon valid document.
  * "Extends" Error
  */
-function InvalidWrite(message, raw) {
-  Error.captureStackTrace(this, InvalidWrite);
-  this.message = message;
+function InvalidWriteError(message, raw) {
+  ThinkyError.call(this, message);
+  this.name = "InvalidWriteError";
   this.raw = raw;
 };
-InvalidWrite.prototype = new Error();
-InvalidWrite.prototype.name = "Invalid write";
-module.exports.InvalidWrite = InvalidWrite;
-
+util.inherits(InvalidWriteError, ThinkyError);
 
 /**
  * ValidationError error which is returned when validation of a document fails.
  * "Extends" Error
  */
-function ValidationError(message) {
-    Error.captureStackTrace(this, ValidationError);
-    this.message = message;
+function ValidationError(message, errors) {
+  ThinkyError.call(this, message || 'Validation Error');
+  this.name = "ValidationError";
+  this.errors = errors || [];
 };
-ValidationError.prototype = new Error();
-ValidationError.prototype.name = "Document failed validation";
-module.exports.ValidationError = ValidationError;
+util.inherits(ValidationError, ThinkyError);
+
+/**
+ * Validation Error Item
+ * Instances of this class are included in the `ValidationError.errors` property.
+ *
+ * @param {string} field    The field that triggered the validation error
+ * @param {string} value    The value that generated the error
+ * @param {string} message  An error message
+ * @constructor
+ */
+function ValidationErrorItem(field, value, message) {
+  this.field = field || null;
+  this.value = value || null;
+  this.message = message || '';
+};
+
+module.exports = {
+  ThinkyError: ThinkyError,
+  DocumentNotFound: DocumentNotFound,
+  InvalidWriteError: InvalidWriteError,
+  ValidationError: ValidationError,
+  ValidationErrorItem: ValidationErrorItem
+};

--- a/lib/query.js
+++ b/lib/query.js
@@ -119,7 +119,7 @@ Query.prototype._execute = function(options, parse, callback) {
         if (self._postValidation === true) {
           var error = null;
           if (result.errors > 0) {
-            return reject(new Errors.InvalidWrite("An error occured during the write", result));
+            return reject(new Errors.InvalidWriteError("An error occured during the write", result));
           }
           if (!Array.isArray(result.changes)) {
             if (self._isPointWrite()) {
@@ -131,7 +131,7 @@ Query.prototype._execute = function(options, parse, callback) {
             return;
           }
           else if (!Array.isArray(result.changes)) {
-            reject(new Errors.InvalidWrite("Field `changes` of a write query not found."));
+            reject(new Errors.InvalidWriteError("Field `changes` of a write query not found."));
           }
 
           var promises = [];
@@ -186,7 +186,7 @@ Query.prototype._execute = function(options, parse, callback) {
                 r.table(self._model.getTableName()).getAll(r.args(primaryKeys)).replace(function(doc) {
                   return r.expr(keysToValues)(doc(self._model._pk));
                 }).run().then(function(result) {
-                  reject(new Errors.InvalidWrite("The write failed, and the changes were reverted"));
+                  reject(new Errors.InvalidWriteError("The write failed, and the changes were reverted"));
                 }).error(function(error) {
                   reject(new Error("The write failed, and the attempt to revert the changes failed with the error:\n"+error.message));
                 });
@@ -253,7 +253,7 @@ Query.prototype._execute = function(options, parse, callback) {
       }).error(function(err) {
         if (err.message.match(/^The query did not find a document and returned null./)) {
           //Reject with an instance of Errors.DocumentNotFound
-          reject(new Errors.DocumentNotFound(err.message))
+          reject(new Errors.DocumentNotFound(err.message));
         }
         else {
           reject(err)

--- a/test/advanced.js
+++ b/test/advanced.js
@@ -649,7 +649,7 @@ describe('Advanced cases', function(){
       });
 
       Model.hasAndBelongsToMany(OtherModel, "links", "id", "id");
-      
+
       OtherModel.hasAndBelongsToMany(Model, "links2", "id", "id");
 
       var values = {};
@@ -675,7 +675,7 @@ describe('Advanced cases', function(){
         assert.equal(doc1.links[1].isSaved(), true);
         assert.equal(doc1.links[2].isSaved(), true);
         assert.strictEqual(doc1, result);
-        
+
         // All saved docs have an id
         assert.equal(typeof doc1.id, 'string');
         assert.equal(typeof doc1.links[0].id, 'string');
@@ -718,7 +718,7 @@ describe('Advanced cases', function(){
           util.sortById(otherDoc3.links2);
           util.sortById(otherDoc4.links2);
 
-          Model.get(doc1.id).getJoin({links: { 
+          Model.get(doc1.id).getJoin({links: {
             _apply: function(seq) {
               return seq.orderBy('id');
             }
@@ -727,7 +727,7 @@ describe('Advanced cases', function(){
             assert.equal(result.links[0].id, doc1.links[0].id);
             assert.equal(result.links[1].id, doc1.links[1].id);
             assert.equal(result.links[2].id, doc1.links[2].id);
-            Model.get(doc2.id).getJoin({links: { 
+            Model.get(doc2.id).getJoin({links: {
               _apply: function(seq) {
                 return seq.orderBy('id');
               }
@@ -981,7 +981,7 @@ describe('Advanced cases', function(){
       }).error(function(error) {
         assert(error instanceof Errors.DocumentNotFound);
         OtherModel.get(otherDoc.id).run().then(function(result) {
-          done(new Error("Was expecting the document to be deleted"));   
+          done(new Error("Was expecting the document to be deleted"));
         }).error(function(error) {
           assert(error instanceof Errors.DocumentNotFound);
           done()
@@ -2354,7 +2354,7 @@ describe('Advanced cases', function(){
       });
 
       Model.hasOne(OtherModel, "otherDoc", "id", "foreignKey");
-       
+
       var doc = new Model({});
       var otherDoc = new OtherModel({});
       doc.otherDoc = otherDoc;
@@ -2383,7 +2383,7 @@ describe('Advanced cases', function(){
       });
 
       Model.hasOne(OtherModel, "otherDoc", "id", "foreignKey");
-       
+
       var doc = new Model({});
       var otherDoc = new OtherModel({});
       doc.otherDoc = otherDoc;
@@ -2411,7 +2411,7 @@ describe('Advanced cases', function(){
       });
 
       Model.hasOne(OtherModel, "otherDoc", "id", "foreignKey");
-       
+
       var doc = new Model({});
       var otherDoc = new OtherModel({});
       doc.otherDoc = otherDoc;
@@ -2443,7 +2443,7 @@ describe('Advanced cases', function(){
       });
 
       Model.hasOne(OtherModel, "otherDoc", "id", "foreignKey");
-       
+
       var doc = new Model({});
       var otherDoc = new OtherModel({});
       doc.otherDoc = otherDoc;
@@ -2474,7 +2474,7 @@ describe('Advanced cases', function(){
       });
 
       Model.belongsTo(OtherModel, "otherDoc", "foreignKey", "id");
-       
+
       var doc = new Model({});
       var otherDoc = new OtherModel({});
       doc.otherDoc = otherDoc;
@@ -2527,7 +2527,7 @@ describe('Advanced cases', function(){
       });
 
       Model.belongsTo(OtherModel, "otherDoc", "foreignKey", "id");
-       
+
       var doc = new Model({});
       var otherDoc = new OtherModel({});
       doc.otherDoc = otherDoc;
@@ -2552,7 +2552,7 @@ describe('Advanced cases', function(){
       });
 
       Model.belongsTo(OtherModel, "otherDoc", "foreignKey", "id");
-      
+
       var doc = new Model({});
       var otherDoc = new OtherModel({});
       doc.otherDoc = otherDoc;
@@ -2585,7 +2585,7 @@ describe('Advanced cases', function(){
       });
 
       Model.hasMany(OtherModel, "otherDocs", "id", "foreignKey");
-       
+
       var doc = new Model({});
       var otherDoc1 = new OtherModel({});
       var otherDoc2 = new OtherModel({});
@@ -2619,7 +2619,7 @@ describe('Advanced cases', function(){
       });
 
       Model.hasMany(OtherModel, "otherDocs", "id", "foreignKey");
-       
+
       var doc = new Model({});
       var otherDoc1 = new OtherModel({});
       var otherDoc2 = new OtherModel({});
@@ -2654,7 +2654,7 @@ describe('Advanced cases', function(){
       });
 
       Model.hasMany(OtherModel, "otherDocs", "id", "foreignKey");
-       
+
       var doc = new Model({});
       var otherDoc1 = new OtherModel({});
       var otherDoc2 = new OtherModel({});
@@ -2693,7 +2693,7 @@ describe('Advanced cases', function(){
       });
 
       Model.hasMany(OtherModel, "otherDocs", "id", "foreignKey");
-       
+
       var doc = new Model({});
       var otherDoc1 = new OtherModel({});
       var otherDoc2 = new OtherModel({});
@@ -2732,7 +2732,7 @@ describe('Advanced cases', function(){
       });
 
       Model.hasAndBelongsToMany(OtherModel, "otherDocs", "id", "id");
-       
+
       var doc = new Model({});
       var otherDoc1 = new OtherModel({});
       var otherDoc2 = new OtherModel({});
@@ -2763,7 +2763,7 @@ describe('Advanced cases', function(){
       });
 
       Model.hasAndBelongsToMany(OtherModel, "otherDocs", "id", "id");
-       
+
       var doc = new Model({});
       var otherDoc1 = new OtherModel({});
       var otherDoc2 = new OtherModel({});
@@ -2793,7 +2793,7 @@ describe('Advanced cases', function(){
       });
 
       Model.hasAndBelongsToMany(OtherModel, "otherDocs", "id", "id");
-       
+
       var doc = new Model({});
       var otherDoc1 = new OtherModel({});
       var otherDoc2 = new OtherModel({});
@@ -2826,7 +2826,7 @@ describe('Advanced cases', function(){
       });
 
       Model.hasAndBelongsToMany(OtherModel, "otherDocs", "id", "id");
-       
+
       var doc = new Model({});
       var otherDoc1 = new OtherModel({});
       var otherDoc2 = new OtherModel({});
@@ -3125,5 +3125,5 @@ describe('Advanced cases', function(){
         done();
       }).catch(done);
     });
-  }); 
+  });
 });

--- a/test/document.js
+++ b/test/document.js
@@ -885,7 +885,7 @@ describe('save', function() {
           done();
         }).error(done);
 
-        
+
       }).error(done);
     })
     it('saveAll should delete links if they are missing', function(done) {
@@ -966,7 +966,7 @@ describe('save', function() {
     })
 
   });
-  
+
   describe('saveAll with missing docs for hasOne', function() {
     afterEach(cleanTables);
 

--- a/test/query.js
+++ b/test/query.js
@@ -201,7 +201,7 @@ describe('Model queries', function() {
     });
   });
 
-   
+
   it('Model.filter() should work', function(done){
     Model.filter(true).run().then(function(result) {
       assert.equal(result.length, 3);
@@ -1000,7 +1000,7 @@ describe('clone', function() {
     var name = util.s8();
     var Model = thinky.createModel(modelNames[0], {id: String});
     var query = Model.filter(true);
-    
+
     var result = 0;
     query.count().execute().then(function(result) {
       assert.equal(result, 0);
@@ -1023,7 +1023,7 @@ describe('optimizer', function() {
   before(function(done) {
     var name = util.s8();
     r.tableCreate(name).run().then(function(result) {
-      
+
       r.table(name).indexCreate('name1').run().then(function() {
 
         Model = thinky.createModel(modelNames[0], {


### PR DESCRIPTION
  - All errors now end with Error, and follow node Error convention
  - Simplified error inheritance with a base error class
  - Added ValidationErrorItem, providing a path for the future for
    multiple validation errors contained in a single error