### PR TITLE
fix `this` ref in docs for models pre save hook

### DIFF
--- a/documentation/api/model.md
+++ b/documentation/api/model.md
@@ -551,7 +551,7 @@ var User = thinky.createModel("User", {
     age: type.number()
 });
 User.pre('save', function(next) {
-    if (age < 18) {
+    if (this.age < 18) {
         next(new Error("A user must be at least 18 years old."));
     }
     else {


### PR DESCRIPTION
The docs had a missing reference to `this` in the pre-save hook example:

