### PR TITLE
`Model.save(object)` should resolve with single object

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -971,8 +971,9 @@ Model.prototype.execute = function(options) {
 Model.prototype.save = function(docs, options) {
   var self = this;
   var r = self._getModel()._thinky.r;
+  var isArray = Array.isArray(docs);
 
-  if (Array.isArray(docs) === false) {
+  if (!isArray) {
     docs = [docs];
   }
 
@@ -1064,6 +1065,11 @@ Model.prototype.save = function(docs, options) {
       });
     }
   })
+
+  if (!isArray) {
+    return p.get(0);
+  }
+
   return p;
 }
 

--- a/test/model.js
+++ b/test/model.js
@@ -181,8 +181,7 @@ describe("Batch insert", function() {
       num: Number
     });
     Model.save({id: "foo"}).then(function(result) {
-      assert.equal(result.length, 1);
-      assert.equal(result[0].id, "foo");
+      assert.deepEqual(result, {id: "foo"});
       done();
     }).error(function(e) {
       done(e);
@@ -245,9 +244,8 @@ describe("Batch insert", function() {
       location: type.point()
     });
     Model.save({id: "foo", location: [1,2]}).then(function(result) {
-      assert.equal(result.length, 1);
-      assert.equal(result[0].id, "foo");
-      assert.equal(result[0].location.$reql_type$, "GEOMETRY");
+      assert.equal(result.id, "foo");
+      assert.equal(result.location.$reql_type$, "GEOMETRY");
       done();
     }).error(function(e) {
       done(e);
@@ -259,11 +257,10 @@ describe("Batch insert", function() {
       num: Number
     });
     Model.save({id: "foo"}).then(function(result) {
-      assert.equal(result.length, 1);
-      assert.equal(result[0].id, "foo");
+      assert.equal(result.id, "foo");
       return Model.save({id: "foo", bar: "buzz"}, {conflict: 'update'});
     }).then(function(result) {
-      assert.deepEqual(result[0], {id: "foo", bar: "buzz"});
+      assert.deepEqual(result, {id: "foo", bar: "buzz"});
       done();
     }).error(function(e) {
       done(e);
@@ -275,11 +272,10 @@ describe("Batch insert", function() {
       num: Number
     });
     Model.save({id: "foo", bar: "buzz"}).then(function(result) {
-      assert.equal(result.length, 1);
-      assert.equal(result[0].id, "foo");
+      assert.equal(result.id, "foo");
       return Model.save({id: "foo"}, {conflict: 'replace'});
     }).then(function(result) {
-      assert.deepEqual(result[0], {id: "foo"});
+      assert.deepEqual(result, {id: "foo"});
       done();
     }).error(function(e) {
       done(e);


### PR DESCRIPTION
Fixes #275. After looking at the tests it appears that we were expecting what I would consider the "incorrect" behavior. If the current behavior is intentional feel free to close this and the related issue, just note that it's not [currently documented](http://thinky.io/documentation/api/model/#save) one way or the other right now.