### PR TITLE
Model promises

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -758,7 +758,7 @@ Document.prototype._saveSelf = function(
     }
   }
 
-  var saveSelfHelper = function() {
+  self.getModel().ready().then(function() {
     util.tryCatch(function() {
       // Validate the document before saving it
       var promise = self.validate();
@@ -777,9 +777,7 @@ Document.prototype._saveSelf = function(
         }).error(reject)
       }
     }, reject);
-  }
-
-  self.getModel().ready().then(saveSelfHelper);
+  });
 }
 
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -580,17 +580,12 @@ Document.prototype._batchSave = function(executeInsert) {
  * @return {Promise}
  */
 Document.prototype._batchSaveSelf = function(executeInsert) {
-  var model = this._getModel();
+  var self = this;
 
   return new Promise(function(resolve, reject) {
-    if (model._tableReady === true) {
+    self.constructor.ready().then(function() {
       executeInsert(resolve, reject)
-    }
-    else {
-      model._onTableReady.push(function() {
-        executeInsert(resolve, reject)
-      });
-    }
+    });
   })
 }
 
@@ -652,18 +647,11 @@ Document.prototype._saveHook = function(docToSave, saveAll, savedModel, callback
     });
 
     //TODO Remove once
-    if (model._tableReady === true) {
+    self.constructor.ready().then(function() {
       Promise.all(promises).then(function() {
         self._onSavedBelongsTo(copy, docToSave, belongsToKeysSaved, saveAll, savedModel, resolve, reject);
       }).error(reject);
-    }
-    else {
-      model._onTableReady.push(function() {
-        Promise.all(promises).then(function() {
-          self._onSavedBelongsTo(copy, docToSave, belongsToKeysSaved, saveAll, savedModel, resolve, reject);
-        }).error(reject);
-      });
-    }
+    });
   });
   return p.nodeify(callback);
 }
@@ -791,14 +779,7 @@ Document.prototype._saveSelf = function(
     }, reject);
   }
 
-  if (self.__proto__._model._tableReady === true) {
-    saveSelfHelper();
-  }
-  else {
-    model.once('ready', function() {
-      saveSelfHelper();
-    })
-  }
+  self.constructor.ready().then(saveSelfHelper);
 }
 
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -583,7 +583,7 @@ Document.prototype._batchSaveSelf = function(executeInsert) {
   var self = this;
 
   return new Promise(function(resolve, reject) {
-    self.constructor.ready().then(function() {
+    self.getModel().ready().then(function() {
       executeInsert(resolve, reject)
     });
   })
@@ -647,7 +647,7 @@ Document.prototype._saveHook = function(docToSave, saveAll, savedModel, callback
     });
 
     //TODO Remove once
-    self.constructor.ready().then(function() {
+    self.getModel().ready().then(function() {
       Promise.all(promises).then(function() {
         self._onSavedBelongsTo(copy, docToSave, belongsToKeysSaved, saveAll, savedModel, resolve, reject);
       }).error(reject);
@@ -779,7 +779,7 @@ Document.prototype._saveSelf = function(
     }, reject);
   }
 
-  self.constructor.ready().then(saveSelfHelper);
+  self.getModel().ready().then(saveSelfHelper);
 }
 
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -512,20 +512,18 @@ Model.prototype.belongsTo = function(joinedModel, fieldDoc, leftKey, rightKey, o
     self._getModel()._tableReady = false;
     joinedModel._getModel()._tableReady = false;
 
-    var query = r.branch(
-      r.table(tableName).indexList().contains(leftKey),
-      r.table(tableName).indexWait(leftKey),
-      r.branch(
-        r.table(tableName).info()("primary_key").eq(leftKey),
-        {index: leftKey, ready: true},
-        r.table(tableName).indexCreate(leftKey).do(function() {
-          return r.table(tableName).indexWait(leftKey)
-        })
-      )
-    )
-
     self.tableReady().then(function() {
-      query.run().then(function(result) {
+      return r.branch(
+        r.table(tableName).indexList().contains(leftKey),
+        r.table(tableName).indexWait(leftKey),
+        r.branch(
+          r.table(tableName).info()("primary_key").eq(leftKey),
+          {index: leftKey, ready: true},
+          r.table(tableName).indexCreate(leftKey).do(function() {
+            return r.table(tableName).indexWait(leftKey)
+          })
+        )
+      ).run().then(function(result) {
         self._indexWasCreated('local');
         self._getModel()._indexes[leftKey] = true;
         joinedModel._indexWasCreated('foreign');
@@ -581,18 +579,6 @@ Model.prototype.hasMany = function(joinedModel, fieldDoc, leftKey, rightKey, opt
     var tableName = joinedModel.getTableName();
     var r = self._getModel()._thinky.r;
 
-    var query = r.branch(
-      r.table(tableName).indexList().contains(rightKey),
-      r.table(tableName).indexWait(rightKey),
-      r.branch(
-        r.table(tableName).info()("primary_key").eq(rightKey),
-        {index: rightKey, ready: true},
-        r.table(tableName).indexCreate(rightKey).do(function() {
-          return r.table(tableName).indexWait(rightKey)
-        })
-      )
-    )
-
     joinedModel._getModel()._indexesToCreate++;
     self._getModel()._foreignIndexesToCreate++;
 
@@ -600,7 +586,17 @@ Model.prototype.hasMany = function(joinedModel, fieldDoc, leftKey, rightKey, opt
     joinedModel._getModel()._tableReady = false;
 
     joinedModel.tableReady().then(function() {
-      query.run().then(function(result) {
+      return r.branch(
+        r.table(tableName).indexList().contains(rightKey),
+        r.table(tableName).indexWait(rightKey),
+        r.branch(
+          r.table(tableName).info()("primary_key").eq(rightKey),
+          {index: rightKey, ready: true},
+          r.table(tableName).indexCreate(rightKey).do(function() {
+            return r.table(tableName).indexWait(rightKey)
+          })
+        )
+      ).run().then(function(result) {
         joinedModel._indexWasCreated('local');
         joinedModel._getModel()._indexes[rightKey] = true;
         self._indexWasCreated('foreign');
@@ -684,39 +680,23 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
   if (options.init !== false) {
     var r = self._getModel()._thinky.r;
 
-    // Create the two indexes on two models
-    var queryIndex1 = r.branch(
-      r.table(self.getTableName()).indexList().contains(leftKey),
-      r.table(self.getTableName()).indexWait(leftKey),
-      r.branch(
-        r.table(self.getTableName()).info()('primary_key').eq(leftKey),
-        {index: leftKey, ready: true},
-        r.table(self.getTableName()).indexCreate(leftKey).do(function() {
-          return r.table(self.getTableName()).indexWait(leftKey)
-        })
-      )
-    );
-
-    // This could try to create the same index, but that's ok
-    var queryIndex2 = r.branch(
-      r.table(joinedModel.getTableName()).indexList().contains(rightKey),
-      r.table(joinedModel.getTableName()).indexWait(rightKey),
-      r.branch(
-        r.table(joinedModel.getTableName()).info()('primary_key').eq(rightKey),
-        {index: rightKey, ready: true},
-        r.table(joinedModel.getTableName()).indexCreate(rightKey).do(function() {
-          return r.table(joinedModel.getTableName()).indexWait(rightKey)
-        })
-      )
-    );
-
     self._getModel()._tableReady = false;
     joinedModel._getModel()._tableReady = false;
     self._getModel()._indexesToCreate++;
     joinedModel._getModel()._foreignIndexesToCreate++;
 
     self.tableReady().then(function() {
-      queryIndex1.run().then(function(result) {
+      return r.branch(
+        r.table(self.getTableName()).indexList().contains(leftKey),
+        r.table(self.getTableName()).indexWait(leftKey),
+        r.branch(
+          r.table(self.getTableName()).info()('primary_key').eq(leftKey),
+          {index: leftKey, ready: true},
+          r.table(self.getTableName()).indexCreate(leftKey).do(function() {
+            return r.table(self.getTableName()).indexWait(leftKey)
+          })
+        )
+      ).run().then(function(result) {
         self._indexWasCreated('local');
         joinedModel._indexWasCreated('foreign');
       }).error(function(error) {
@@ -735,7 +715,17 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
     self._getModel()._foreignIndexesToCreate++;
 
     joinedModel.tableReady().then(function() {
-      queryIndex2.run().then(function(result) {
+      return r.branch(
+        r.table(joinedModel.getTableName()).indexList().contains(rightKey),
+        r.table(joinedModel.getTableName()).indexWait(rightKey),
+        r.branch(
+          r.table(joinedModel.getTableName()).info()('primary_key').eq(rightKey),
+          {index: rightKey, ready: true},
+          r.table(joinedModel.getTableName()).indexCreate(rightKey).do(function() {
+            return r.table(joinedModel.getTableName()).indexWait(rightKey)
+          })
+        )
+      ).run().then(function(result) {
         joinedModel._indexWasCreated('local');
         self._indexWasCreated('foreign');
       }).error(function(error) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -219,7 +219,10 @@ Model.prototype.tableReady = function() {
   });
 
   return this._tableReadyPromise.then(function() {
-     self._tableWasCreated();
+    self.emit('created');
+    if (!self._pendingPromises.length) {
+      self.emit('ready');
+    }
   });
 };
 
@@ -262,7 +265,16 @@ Model.prototype._promisesReady = function() {
 };
 
 Model.prototype._waitFor = function(promise) {
+  var self = this;
   this._pendingPromises.push(promise);
+
+  // Emit 'ready' when all pending promises have resolved
+  if (!this._pendingReady) {
+    this._pendingReady = this._promisesReady().then(function() {
+      delete self._pendingReady;
+      self.emit('ready', self);
+    });
+  }
 };
 
 Model.prototype.isReady = function() {

--- a/lib/model.js
+++ b/lib/model.js
@@ -329,13 +329,7 @@ Model.prototype.fetchIndexes = function() {
 
     }
 
-    if (self._getModel()._tableCreated === true) {
-      fetch();
-    }
-    else {
-      self._getModel()._onTableCreated.push(fetch);
-    }
-
+    self.tableReady().then(fetch);
   });
 }
 
@@ -385,12 +379,7 @@ Model.prototype.ensureIndex = function(name, fn, opts) {
 
     }
 
-    if (self._getModel()._tableCreated === true) {
-      ensureIndex();
-    }
-    else {
-      self._getModel()._onTableCreated.push(ensureIndex);
-    }
+    self.tableReady().then(ensureIndex);
   })
 }
 
@@ -444,7 +433,7 @@ Model.prototype.hasOne = function(joinedModel, fieldDoc, leftKey, rightKey, opti
     self._getModel()._tableReady = false;
     joinedModel._getModel()._tableReady = false;
 
-    if (joinedModel._getModel()._tableCreated === true) {
+    joinedModel.tableReady().then(function() {
       return r.branch(
         r.table(tableName).indexList().contains(rightKey),
         r.table(tableName).indexWait(rightKey),
@@ -469,35 +458,7 @@ Model.prototype.hasOne = function(joinedModel, fieldDoc, leftKey, rightKey, opti
           self._getModel()._setError(error);
         }
       })
-    }
-    else {
-      joinedModel._getModel()._onTableCreated.push(function() {
-        r.branch(
-          r.table(tableName).indexList().contains(rightKey),
-          r.table(tableName).indexWait(rightKey),
-          r.branch(
-            r.table(tableName).info()("primary_key").eq(rightKey),
-            r.table(tableName).indexWait(rightKey),
-            r.table(tableName).indexCreate(rightKey).do(function() {
-              return r.table(tableName).indexWait(rightKey)
-            })
-          )
-        ).run().then(function() {
-          joinedModel._indexWasCreated('local');
-          joinedModel._getModel()._indexes[rightKey] = true;
-          self._indexWasCreated('foreign');
-        }).error(function(error) {
-          if (error.message.match(/^Index `/)) {
-            joinedModel._indexWasCreated('local');
-            self._indexWasCreated('foreign');
-          }
-          else {
-            joinedModel._getModel()._setError(error);
-            self._getModel()._setError(error);
-          }
-        })
-      })
-    }
+    });
   }
 }
 
@@ -563,9 +524,10 @@ Model.prototype.belongsTo = function(joinedModel, fieldDoc, leftKey, rightKey, o
       )
     )
 
-    if (self._getModel()._tableCreated === true) {
+    self.tableReady().then(function() {
       query.run().then(function(result) {
         self._indexWasCreated('local');
+        self._getModel()._indexes[leftKey] = true;
         joinedModel._indexWasCreated('foreign');
       }).error(function(error) {
         if (error.message.match(/^Index `/)) {
@@ -578,25 +540,7 @@ Model.prototype.belongsTo = function(joinedModel, fieldDoc, leftKey, rightKey, o
           self._getModel()._setError(error);
         }
       })
-    }
-    else {
-      self._getModel()._onTableCreated.push(function() {
-        query.run().then(function() {
-          self._indexWasCreated('local');
-          self._getModel()._indexes[leftKey] = true;
-          joinedModel._indexWasCreated('foreign');
-        }).error(function(error) {
-          if (error.message.match(/^Index `/)) {
-            self._indexWasCreated('local');
-            joinedModel._indexWasCreated('foreign');
-          }
-          else {
-            joinedModel._getModel()._setError(error);
-            self._getModel()._setError(error);
-          }
-        });
-      })
-    }
+    });
   }
 }
 
@@ -655,7 +599,7 @@ Model.prototype.hasMany = function(joinedModel, fieldDoc, leftKey, rightKey, opt
     self._getModel()._tableReady = false;
     joinedModel._getModel()._tableReady = false;
 
-    if (joinedModel._getModel()._tableCreated === true) {
+    joinedModel.tableReady().then(function() {
       query.run().then(function(result) {
         joinedModel._indexWasCreated('local');
         joinedModel._getModel()._indexes[rightKey] = true;
@@ -670,25 +614,7 @@ Model.prototype.hasMany = function(joinedModel, fieldDoc, leftKey, rightKey, opt
           joinedModel._getModel()._setError(error);
         }
       })
-    }
-    else {
-      joinedModel._getModel()._onTableCreated.push(function() {
-        query.run().then(function() {
-          joinedModel._indexWasCreated('local');
-          joinedModel._getModel()._indexes[rightKey] = true;
-          self._indexWasCreated('foreign');
-        }).error(function(error) {
-          if (error.message.match(/^Index `.*` already exists/)) {
-            joinedModel._indexWasCreated('local');
-            self._indexWasCreated('foreign');
-          }
-          else {
-            self._getModel()._setError(error);
-            joinedModel._getModel()._setError(error);
-          }
-        })
-      })
-    }
+    });
   }
 }
 
@@ -788,7 +714,8 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
     joinedModel._getModel()._tableReady = false;
     self._getModel()._indexesToCreate++;
     joinedModel._getModel()._foreignIndexesToCreate++;
-    if (self._getModel()._tableCreated === true) {
+
+    self.tableReady().then(function() {
       queryIndex1.run().then(function(result) {
         self._indexWasCreated('local');
         joinedModel._indexWasCreated('foreign');
@@ -802,27 +729,12 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
           joinedModel._getModel()._setError(error);
         }
       })
-    }
-    else {
-      self._getModel()._onTableCreated.push(function() {
-        queryIndex1.run().then(function() {
-          self._indexWasCreated('local');
-          joinedModel._indexWasCreated('foreign');
-        }).error(function(error) {
-          if (error.message.match(/^Index `/)) {
-            self._indexWasCreated('local');
-            joinedModel._indexWasCreated('foreign');
-          }
-          else {
-            self._getModel()._setError(error);
-          }
-        });
-      });
-    }
+    });
 
     joinedModel._getModel()._indexesToCreate++;
     self._getModel()._foreignIndexesToCreate++;
-    if (joinedModel._getModel()._tableCreated === true) {
+
+    joinedModel.tableReady().then(function() {
       queryIndex2.run().then(function(result) {
         joinedModel._indexWasCreated('local');
         self._indexWasCreated('foreign');
@@ -836,24 +748,7 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
           joinedModel._getModel()._setError(error);
         }
       })
-    }
-    else {
-      joinedModel._getModel()._onTableCreated.push(function() {
-        queryIndex2.run().then(function() {
-          joinedModel._indexWasCreated('local');
-          self._indexWasCreated('foreign');
-        }).error(function(error) {
-          if (error.message.match(/^Index `/)) {
-            joinedModel._indexWasCreated('local');
-            self._indexWasCreated('foreign');
-          }
-          else {
-            self._getModel()._setError(error);
-            joinedModel._getModel()._setError(error);
-          }
-        });
-      });
-    }
+    });
 
     var query;
     if ((this.getTableName() === joinedModel.getTableName())
@@ -919,14 +814,9 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
 
       self._getModel()._foreignIndexesToCreate++;
       joinedModel._getModel()._foreignIndexesToCreate++;
-      if (linkModel._getModel()._tableReady === true) {
+      linkModel.tableReady().then(function() {
         query.run().then(successCb).error(errorCb)
-      }
-      else {
-        linkModel._getModel()._onTableCreated.push(function() {
-          query.run().then(successCb).error(errorCb)
-        });
-      }
+      });
     })
   }
 };

--- a/lib/model.js
+++ b/lib/model.js
@@ -54,6 +54,7 @@ function Model(name, schema, options, thinky) {
   this._indexesToCreate = 0;
   this._foreignIndexesToCreate = 0; // many to many indexes left to create
   this._indexes = {}; // indexName -> true
+  this._pendingPromises = [];
 
   this._error = null; // If an error occured, we won't let people save things
 
@@ -222,6 +223,48 @@ Model.prototype.tableReady = function() {
   });
 };
 
+/**
+ * Get a promise which resolves when the Model's table and
+ * all indices have been created.
+ */
+Model.prototype.ready = function() {
+  var requirements = [];
+
+  // Ensure the Model's table is ready
+  requirements.push(this.tableReady());
+
+  // Ensure all other pending promises have been resolved
+  requirements.push(this._promisesReady());
+
+  return Promise.all(requirements);
+};
+
+Model.prototype._promisesReady = function() {
+  var self = this;
+  if (this._promisesReadyPromise) return this._promisesReadyPromise;
+
+  var verifyAll = function() {
+    return Promise.all(self._pendingPromises)
+    .then(function() {
+      var i, allFullfilled = true;
+      for (i=0; i<self._pendingPromises.length; i++) {
+         if (!self._pendingPromises[i].isFulfilled()) {
+          allFullfilled = false;
+          break;
+         }
+      }
+      return allFullfilled ? Promise.resolve() : verifyAll();
+    });
+  };
+
+  this._promisesReadyPromise = verifyAll();
+  return this._promisesReadyPromise;
+};
+
+Model.prototype._waitFor = function(promise) {
+  this._pendingPromises.push(promise);
+};
+
 Model.prototype.isReady = function() {
   return this._getModel()._tableReady;
 }
@@ -364,7 +407,7 @@ Model.prototype._createIndex = function(name, fn, opts) {
     fn = undefined;
   }
 
-  return this.tableReady().then(function() {
+  var promise = this.tableReady().then(function() {
     return new Promise(function(resolve, reject) {
       return r.branch(
         r.table(tableName).indexList().contains(name),
@@ -393,6 +436,9 @@ Model.prototype._createIndex = function(name, fn, opts) {
   .then(function() {
     model._indexes[name] = true;
   });
+
+  this._waitFor(promise);
+  return promise;
 };
 
 /*

--- a/lib/model.js
+++ b/lib/model.js
@@ -400,9 +400,6 @@ Model.prototype.ensureIndex = function(name, fn, opts) {
   self._getModel()._tableReady = false;
 
   return self._createIndex(name, fn, opts)
-  .then(function() {
-    self._indexWasCreated('local');
-  })
   .catch(function(error) {
     self._getModel()._setError(error);
     throw error;
@@ -499,16 +496,12 @@ Model.prototype.hasOne = function(joinedModel, fieldDoc, leftKey, rightKey, opti
 
     self._getModel()._tableReady = false;
     joinedModel._getModel()._tableReady = false;
-
-    joinedModel._createIndex(rightKey)
-    .then(function() {
-      joinedModel._indexWasCreated('local');
-      self._indexWasCreated('foreign');
-    })
+    var newIndex = joinedModel._createIndex(rightKey)
     .catch(function(error) {
       joinedModel._getModel()._setError(error);
       self._getModel()._setError(error);
     });
+    self._waitFor(newIndex);
   }
 }
 
@@ -558,16 +551,12 @@ Model.prototype.belongsTo = function(joinedModel, fieldDoc, leftKey, rightKey, o
 
     self._getModel()._tableReady = false;
     joinedModel._getModel()._tableReady = false;
-
-    self._createIndex(leftKey)
-    .then(function() {
-      self._indexWasCreated('local');
-      joinedModel._indexWasCreated('foreign');
-    })
+    var newIndex = self._createIndex(leftKey)
     .catch(function(error) {
       joinedModel._getModel()._setError(error);
       self._getModel()._setError(error);
     });
+    joinedModel._waitFor(newIndex);
   }
 }
 
@@ -610,16 +599,12 @@ Model.prototype.hasMany = function(joinedModel, fieldDoc, leftKey, rightKey, opt
 
     self._getModel()._tableReady = false;
     joinedModel._getModel()._tableReady = false;
-
-    joinedModel._createIndex(rightKey)
-    .then(function() {
-      self._indexWasCreated('foreign');
-      joinedModel._indexWasCreated('local');
-    })
+    var newIndex = joinedModel._createIndex(rightKey)
     .catch(function(error) {
       self._getModel()._setError(error);
       joinedModel._getModel()._setError(error);
     });
+    self._waitFor(newIndex);
   }
 }
 
@@ -730,23 +715,17 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
 
     }
 
-    return linkModel.ready().then(function() {
+    var linkPromise = linkModel.ready().then(function() {
       var successCb = function() {
-        self._indexWasCreated('foreign');
-        joinedModel._indexWasCreated('foreign');
         self._getModel()._indexes[leftKey] = true;
         joinedModel._getModel()._indexes[rightKey] = true;
       }
 
       var errorCb = function(error) {
         if (error.message.match(/^Index `/)) {
-          self._indexWasCreated('foreign');
-          joinedModel._indexWasCreated('foreign');
           return;
         }
         else if (error.message.match(/^Table `.*` already exists/)) {
-          self._indexWasCreated('foreign');
-          joinedModel._indexWasCreated('foreign');
           return;
         }
 
@@ -782,6 +761,11 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
         joinedModel._getModel()._setError(error);
       });
     });
+
+    joinedModel._waitFor(linkPromise);
+    self._waitFor(linkPromise);
+
+    return Promise.all([self.ready(), joinedModel.ready()]);
   }
 };
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -383,6 +383,42 @@ Model.prototype.ensureIndex = function(name, fn, opts) {
   })
 }
 
+Model.prototype._createIndex = function(name) {
+  var model = this._getModel();
+  var tableName = this.getTableName();
+  var r = model._thinky.r;
+
+  return this.tableReady().then(function() {
+    return new Promise(function(resolve, reject) {
+      return r.branch(
+        r.table(tableName).indexList().contains(name),
+        r.table(tableName).indexWait(name),
+        r.branch(
+          r.table(tableName).info()('primary_key').eq(name),
+          r.table(tableName).indexWait(name),
+          r.table(tableName).indexCreate(name).do(function() {
+            return r.table(tableName).indexWait(name);
+          })
+        )
+      )
+      .run()
+      .then(resolve)
+      .error(function(error) {
+        if (error.message.match(/^Index/)) {
+          // TODO: This regex seems a bit too generous since messages such
+          // as "Index `id` was not found on table..." will be accepted.
+          // Figure out if this is OK or not.
+          return resolve();
+        }
+        reject(error);
+      });
+    });
+  })
+  .then(function() {
+    model._indexes[name] = true;
+  });
+};
+
 /*
  * joinedModel: the joined model
  * fieldDoc: the field where the joined document will be kept

--- a/lib/model.js
+++ b/lib/model.js
@@ -196,15 +196,12 @@ Model.prototype.tableReady = function() {
   var r = model._thinky.r;
   this._tableReadyPromise = model._thinky.dbReady()
   .then(function() {
-    return r.tableList().contains(model._name).do(function(result) {
-      return r.branch(
-        result,
-        {created: 0},
-        r.tableCreate(model._name, {primaryKey: model._pk})
-      );
-    }).run();
+    return r.tableCreate(model._name, {primaryKey: model._pk}).run();
   })
   .error(function(error) {
+    if (error.message.match(/Table `.*` already exists/)) {
+      return;
+    }
     model._error = error;
     // Should we throw here?
   });

--- a/lib/model.js
+++ b/lib/model.js
@@ -383,10 +383,15 @@ Model.prototype.ensureIndex = function(name, fn, opts) {
   })
 }
 
-Model.prototype._createIndex = function(name) {
+Model.prototype._createIndex = function(name, fn, opts) {
   var model = this._getModel();
   var tableName = this.getTableName();
   var r = model._thinky.r;
+
+  if (opts === undefined && util.isPlainObject(fn)) {
+    opts = fn;
+    fn = undefined;
+  }
 
   return this.tableReady().then(function() {
     return new Promise(function(resolve, reject) {
@@ -396,7 +401,7 @@ Model.prototype._createIndex = function(name) {
         r.branch(
           r.table(tableName).info()('primary_key').eq(name),
           r.table(tableName).indexWait(name),
-          r.table(tableName).indexCreate(name).do(function() {
+          r.table(tableName).indexCreate(name, fn, opts).do(function() {
             return r.table(tableName).indexWait(name);
           })
         )

--- a/lib/model.js
+++ b/lib/model.js
@@ -460,40 +460,20 @@ Model.prototype.hasOne = function(joinedModel, fieldDoc, leftKey, rightKey, opti
 
   options = options || {};
   if (options.init !== false) {
-    var tableName = joinedModel.getTableName();
-    var r = joinedModel._getModel()._thinky.r;
-
     joinedModel._getModel()._indexesToCreate++;
     self._getModel()._foreignIndexesToCreate++;
 
     self._getModel()._tableReady = false;
     joinedModel._getModel()._tableReady = false;
 
-    joinedModel.tableReady().then(function() {
-      return r.branch(
-        r.table(tableName).indexList().contains(rightKey),
-        r.table(tableName).indexWait(rightKey),
-        r.branch(
-          r.table(tableName).info()("primary_key").eq(rightKey),
-          r.table(tableName).indexWait(rightKey),
-          r.table(tableName).indexCreate(rightKey).do(function() {
-            return r.table(tableName).indexWait(rightKey)
-          })
-        )
-      ).run().then(function(result) {
+    joinedModel._createIndex(rightKey)
+    .then(function() {
         joinedModel._indexWasCreated('local');
-        joinedModel._getModel()._indexes[rightKey] = true;
         self._indexWasCreated('foreign');
-      }).error(function(error) {
-        if (error.message.match(/^Index `/)) {
-          joinedModel._indexWasCreated('local');
-          self._indexWasCreated('foreign');
-        }
-        else {
-          joinedModel._getModel()._setError(error);
-          self._getModel()._setError(error);
-        }
-      })
+    })
+    .catch(function(error) {
+      joinedModel._getModel()._setError(error);
+      self._getModel()._setError(error);
     });
   }
 }
@@ -539,41 +519,20 @@ Model.prototype.belongsTo = function(joinedModel, fieldDoc, leftKey, rightKey, o
 
   options = options || {};
   if (options.init !== false) {
-    var tableName = self.getTableName();
-    var r = self._getModel()._thinky.r;
-
     self._getModel()._indexesToCreate++;
     joinedModel._getModel()._foreignIndexesToCreate++;
 
     self._getModel()._tableReady = false;
     joinedModel._getModel()._tableReady = false;
 
-    self.tableReady().then(function() {
-      return r.branch(
-        r.table(tableName).indexList().contains(leftKey),
-        r.table(tableName).indexWait(leftKey),
-        r.branch(
-          r.table(tableName).info()("primary_key").eq(leftKey),
-          {index: leftKey, ready: true},
-          r.table(tableName).indexCreate(leftKey).do(function() {
-            return r.table(tableName).indexWait(leftKey)
-          })
-        )
-      ).run().then(function(result) {
-        self._indexWasCreated('local');
-        self._getModel()._indexes[leftKey] = true;
-        joinedModel._indexWasCreated('foreign');
-      }).error(function(error) {
-        if (error.message.match(/^Index `/)) {
-          self._indexWasCreated('local');
-          self._getModel()._indexes[leftKey] = true;
-          joinedModel._indexWasCreated('foreign');
-        }
-        else {
-          joinedModel._getModel()._setError(error);
-          self._getModel()._setError(error);
-        }
-      })
+    self._createIndex(leftKey)
+    .then(function() {
+      self._indexWasCreated('local');
+      joinedModel._indexWasCreated('foreign');
+    })
+    .catch(function(error) {
+      joinedModel._getModel()._setError(error);
+      self._getModel()._setError(error);
     });
   }
 }
@@ -612,40 +571,20 @@ Model.prototype.hasMany = function(joinedModel, fieldDoc, leftKey, rightKey, opt
 
   options = options || {};
   if (options.init !== false) {
-    var tableName = joinedModel.getTableName();
-    var r = self._getModel()._thinky.r;
-
     joinedModel._getModel()._indexesToCreate++;
     self._getModel()._foreignIndexesToCreate++;
 
     self._getModel()._tableReady = false;
     joinedModel._getModel()._tableReady = false;
 
-    joinedModel.tableReady().then(function() {
-      return r.branch(
-        r.table(tableName).indexList().contains(rightKey),
-        r.table(tableName).indexWait(rightKey),
-        r.branch(
-          r.table(tableName).info()("primary_key").eq(rightKey),
-          {index: rightKey, ready: true},
-          r.table(tableName).indexCreate(rightKey).do(function() {
-            return r.table(tableName).indexWait(rightKey)
-          })
-        )
-      ).run().then(function(result) {
-        joinedModel._indexWasCreated('local');
-        joinedModel._getModel()._indexes[rightKey] = true;
-        self._indexWasCreated('foreign');
-      }).error(function(error) {
-        if (error.message.match(/^Index `.*` already exists/)) {
-          joinedModel._indexWasCreated('local');
-          self._indexWasCreated('foreign');
-        }
-        else {
-          self._getModel()._setError(error);
-          joinedModel._getModel()._setError(error);
-        }
-      })
+    joinedModel._createIndex(rightKey)
+    .then(function() {
+      self._indexWasCreated('foreign');
+      joinedModel._indexWasCreated('local');
+    })
+    .catch(function(error) {
+      self._getModel()._setError(error);
+      joinedModel._getModel()._setError(error);
     });
   }
 }
@@ -721,59 +660,27 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
     self._getModel()._indexesToCreate++;
     joinedModel._getModel()._foreignIndexesToCreate++;
 
-    self.tableReady().then(function() {
-      return r.branch(
-        r.table(self.getTableName()).indexList().contains(leftKey),
-        r.table(self.getTableName()).indexWait(leftKey),
-        r.branch(
-          r.table(self.getTableName()).info()('primary_key').eq(leftKey),
-          {index: leftKey, ready: true},
-          r.table(self.getTableName()).indexCreate(leftKey).do(function() {
-            return r.table(self.getTableName()).indexWait(leftKey)
-          })
-        )
-      ).run().then(function(result) {
-        self._indexWasCreated('local');
-        joinedModel._indexWasCreated('foreign');
-      }).error(function(error) {
-        if (error.message.match(/^Index `/)) {
-          self._indexWasCreated('local');
-          joinedModel._indexWasCreated('foreign');
-        }
-        else {
-          self._getModel()._setError(error);
-          joinedModel._getModel()._setError(error);
-        }
-      })
+    self._createIndex(leftKey)
+    .then(function() {
+      self._indexWasCreated('local');
+      joinedModel._indexWasCreated('foreign');
+    })
+    .catch(function(error) {
+      self._getModel()._setError(error);
+      joinedModel._getModel()._setError(error);
     });
 
     joinedModel._getModel()._indexesToCreate++;
     self._getModel()._foreignIndexesToCreate++;
 
-    joinedModel.tableReady().then(function() {
-      return r.branch(
-        r.table(joinedModel.getTableName()).indexList().contains(rightKey),
-        r.table(joinedModel.getTableName()).indexWait(rightKey),
-        r.branch(
-          r.table(joinedModel.getTableName()).info()('primary_key').eq(rightKey),
-          {index: rightKey, ready: true},
-          r.table(joinedModel.getTableName()).indexCreate(rightKey).do(function() {
-            return r.table(joinedModel.getTableName()).indexWait(rightKey)
-          })
-        )
-      ).run().then(function(result) {
-        joinedModel._indexWasCreated('local');
-        self._indexWasCreated('foreign');
-      }).error(function(error) {
-        if (error.message.match(/^Index `/)) {
-          joinedModel._indexWasCreated('local');
-          self._indexWasCreated('foreign');
-        }
-        else {
-          self._getModel()._setError(error);
-          joinedModel._getModel()._setError(error);
-        }
-      })
+    joinedModel._createIndex(rightKey)
+    .then(function() {
+      self._indexWasCreated('foreign');
+      joinedModel._indexWasCreated('local');
+    })
+    .catch(function(error) {
+      self._getModel()._setError(error);
+      joinedModel._getModel()._setError(error);
     });
 
     var query;

--- a/lib/model.js
+++ b/lib/model.js
@@ -681,29 +681,8 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
     joinedModel._getModel()._tableReady = false;
     self._getModel()._indexesToCreate++;
     joinedModel._getModel()._foreignIndexesToCreate++;
-
-    self._createIndex(leftKey)
-    .then(function() {
-      self._indexWasCreated('local');
-      joinedModel._indexWasCreated('foreign');
-    })
-    .catch(function(error) {
-      self._getModel()._setError(error);
-      joinedModel._getModel()._setError(error);
-    });
-
     joinedModel._getModel()._indexesToCreate++;
     self._getModel()._foreignIndexesToCreate++;
-
-    joinedModel._createIndex(rightKey)
-    .then(function() {
-      self._indexWasCreated('foreign');
-      joinedModel._indexWasCreated('local');
-    })
-    .catch(function(error) {
-      self._getModel()._setError(error);
-      joinedModel._getModel()._setError(error);
-    });
 
     var query;
     if ((this.getTableName() === joinedModel.getTableName())
@@ -739,40 +718,58 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
 
     }
 
-    return new Promise(function(resolve, reject) {
+    return linkModel.ready().then(function() {
       var successCb = function() {
         self._indexWasCreated('foreign');
         joinedModel._indexWasCreated('foreign');
         self._getModel()._indexes[leftKey] = true;
         joinedModel._getModel()._indexes[rightKey] = true;
-        resolve();
       }
 
       var errorCb = function(error) {
         if (error.message.match(/^Index `/)) {
           self._indexWasCreated('foreign');
           joinedModel._indexWasCreated('foreign');
-          resolve();
+          return;
         }
         else if (error.message.match(/^Table `.*` already exists/)) {
           self._indexWasCreated('foreign');
           joinedModel._indexWasCreated('foreign');
-          resolve();
+          return;
         }
 
         else {
           self._getModel()._setError(error);
           joinedModel._getModel()._setError(error);
-          reject(error);
+          throw error;
         }
       }
 
       self._getModel()._foreignIndexesToCreate++;
       joinedModel._getModel()._foreignIndexesToCreate++;
-      linkModel.tableReady().then(function() {
-        query.run().then(successCb).error(errorCb)
-      });
+      return query.run().then(successCb).error(errorCb);
     })
+    .then(function() {
+      self._createIndex(leftKey)
+      .then(function() {
+        self._indexWasCreated('local');
+        joinedModel._indexWasCreated('foreign');
+      })
+      .catch(function(error) {
+        self._getModel()._setError(error);
+        joinedModel._getModel()._setError(error);
+      });
+
+      joinedModel._createIndex(rightKey)
+      .then(function() {
+        self._indexWasCreated('foreign');
+        joinedModel._indexWasCreated('local');
+      })
+      .catch(function(error) {
+        self._getModel()._setError(error);
+        joinedModel._getModel()._setError(error);
+      });
+    });
   }
 };
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -335,7 +335,6 @@ Model.prototype.fetchIndexes = function() {
 
 Model.prototype.ensureIndex = function(name, fn, opts) {
   var self = this;
-  var r = self._getModel()._thinky.r;
 
   if ((opts === undefined) && (util.isPlainObject(fn))) {
     opts = fn;
@@ -345,42 +344,14 @@ Model.prototype.ensureIndex = function(name, fn, opts) {
   self._getModel()._indexesToCreate++;
   self._getModel()._tableReady = false;
 
-  return new Promise(function(resolve, reject) {
-    var ensureIndex = function() {
-      if (fn === undefined) {
-        fn = function(doc) { return doc(name) };
-      }
-      var tableName = self.getTableName();
-      return r.branch(
-        r.table(tableName).indexList().contains(name),
-        r.table(tableName).indexWait(name),
-        r.branch(
-          r.table(tableName).info()("primary_key").eq(name),
-          r.table(tableName).indexWait(name),
-          r.table(tableName).indexCreate(name, fn, opts || {}).do(function() {
-            return r.table(tableName).indexWait(name)
-          })
-        )
-      ).run().then(function(result) {
-        self._getModel()._indexes[name] = true;
-        self._indexWasCreated('local');
-
-        resolve();
-      }).error(function(error) {
-        if (error.message.match(/^Index `/)) {
-          self._indexWasCreated('local');
-        }
-        else {
-          self._getModel()._setError(error);
-        }
-
-        reject(error)
-      })
-
-    }
-
-    self.tableReady().then(ensureIndex);
+  return self._createIndex(name, fn, opts)
+  .then(function() {
+    self._indexWasCreated('local');
   })
+  .catch(function(error) {
+    self._getModel()._setError(error);
+    throw error;
+  });
 }
 
 Model.prototype._createIndex = function(name, fn, opts) {
@@ -473,8 +444,8 @@ Model.prototype.hasOne = function(joinedModel, fieldDoc, leftKey, rightKey, opti
 
     joinedModel._createIndex(rightKey)
     .then(function() {
-        joinedModel._indexWasCreated('local');
-        self._indexWasCreated('foreign');
+      joinedModel._indexWasCreated('local');
+      self._indexWasCreated('foreign');
     })
     .catch(function(error) {
       joinedModel._getModel()._setError(error);

--- a/lib/model.js
+++ b/lib/model.js
@@ -601,27 +601,22 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
     }
 
     var linkPromise = linkModel.ready().then(function() {
-      var successCb = function() {
+      return query.run()
+      .then(function() {
         self._getModel()._indexes[leftKey] = true;
         joinedModel._getModel()._indexes[rightKey] = true;
-      }
-
-      var errorCb = function(error) {
+      })
+      .error(function(error) {
         if (error.message.match(/^Index `/)) {
           return;
         }
-        else if (error.message.match(/^Table `.*` already exists/)) {
+        if (error.message.match(/^Table `.*` already exists/)) {
           return;
         }
-
-        else {
-          self._getModel()._setError(error);
-          joinedModel._getModel()._setError(error);
-          throw error;
-        }
-      }
-
-      return query.run().then(successCb).error(errorCb);
+        self._getModel()._setError(error);
+        joinedModel._getModel()._setError(error);
+        throw error;
+      });
     })
     .then(function() {
       self._createIndex(leftKey)

--- a/lib/model.js
+++ b/lib/model.js
@@ -93,6 +93,7 @@ util.inherits(Model, EventEmitter);
 Model.new = function(name, schema, options, thinky) {
 
   var proto = new Model(name, schema, options, thinky);
+  proto._initModel = options.init  !== undefined ? !!options.init : true;
 
   var model = function model(doc, options) {
     if (!util.isPlainObject(doc)) {
@@ -161,6 +162,19 @@ Model.new = function(name, schema, options, thinky) {
 
   model.__proto__ = proto;
 
+  if (options.init !== false) {
+    // Setup the model's table.
+    model.tableReady().then();
+  }
+  else {
+    // We do not initialize the table and suppose that it already exists and
+    // is ready.
+    model._getModel()._tableCreated = true;
+    model.emit('created');
+    model._getModel()._tableReady = true;
+    model.emit('ready');
+  }
+
   // So people can directly call the EventEmitter from the constructor
   // TOIMPROVE: We should emit everything from the constructor instead of emitting things from
   // the constructor and the instance of Model
@@ -175,6 +189,38 @@ Model.new = function(name, schema, options, thinky) {
 
   return model
 }
+
+/**
+ * Create the model's table.
+ * @return {Promise=} Returns a promise which will resolve when the table is ready.
+ */
+Model.prototype.tableReady = function() {
+  var self = this;
+  var model = this._getModel();
+  if (!this._initModel) return Promise.resolve();
+  if (this._tableReadyPromise) return this._tableReadyPromise;
+
+  // Create the table, or push the table name in the queue.
+  var r = model._thinky.r;
+  this._tableReadyPromise = model._thinky.dbReady()
+  .then(function() {
+    return r.tableList().contains(model._name).do(function(result) {
+      return r.branch(
+        result,
+        {created: 0},
+        r.tableCreate(model._name, {primaryKey: model._pk})
+      );
+    }).run();
+  })
+  .error(function(error) {
+    model._error = error;
+    // Should we throw here?
+  });
+
+  return this._tableReadyPromise.then(function() {
+     self._tableWasCreated();
+  });
+};
 
 Model.prototype.isReady = function() {
   return this._getModel()._tableReady;

--- a/lib/model.js
+++ b/lib/model.js
@@ -46,13 +46,6 @@ function Model(name, schema, options, thinky) {
 
   this._validator = options.validator;
 
-  this._tableCreated = false;
-  this._tableReady = false;
-  this._onTableCreated = [];
-  this._onTableReady = [];
-  this._indexesFetched = false; // Whether the indexes were fetched or not
-  this._indexesToCreate = 0;
-  this._foreignIndexesToCreate = 0; // many to many indexes left to create
   this._indexes = {}; // indexName -> true
   this._pendingPromises = [];
 
@@ -170,9 +163,7 @@ Model.new = function(name, schema, options, thinky) {
   else {
     // We do not initialize the table and suppose that it already exists and
     // is ready.
-    model._getModel()._tableCreated = true;
     model.emit('created');
-    model._getModel()._tableReady = true;
     model.emit('ready');
   }
 
@@ -277,61 +268,12 @@ Model.prototype._waitFor = function(promise) {
   }
 };
 
-Model.prototype.isReady = function() {
-  return this._getModel()._tableReady;
-}
 
 Model.prototype._setError = function(error) {
   this._getModel()._error = error;
   this.emit('error', error);
 }
 
-Model.prototype._setReady = function() {
-  this._getModel()._tableReady = true;
-  this.emit('ready', this);
-  while (this._getModel()._onTableReady.length > 0) {
-    this._getModel()._onTableReady.shift()();
-  }
-}
-
-Model.prototype._indexWasCreated = function(type) {
-  if (type === 'local') {
-    this._getModel()._indexesToCreate--;
-  }
-  else if (type === 'foreign') {
-    this._getModel()._foreignIndexesToCreate--;
-  }
-  // We need to check tableCreated because _indexWasCreated can be called when a foreign index is built.
-  if ((this._getModel()._tableCreated === true)
-    && (this._getModel()._indexesToCreate === 0)
-    && (this._getModel()._foreignIndexesToCreate === 0)
-    && (this._getModel()._indexesFetched === true)) {
-
-    this._setReady();
-  }
-}
-
-
-Model.prototype._tableWasCreated = function() {
-  var self = this;
-
-  self._getModel()._tableCreated = true;
-  while (this._getModel()._onTableCreated.length > 0) {
-    this._getModel()._onTableCreated.shift()();
-  }
-
-  self.emit('created');
-
-  self.fetchIndexes().then(function() {
-    if ((self._getModel()._indexesToCreate === 0)
-      && (self._getModel()._foreignIndexesToCreate === 0)) {
-      // Will trigger the queries waiting
-      this._setReady();
-    }
-  }).error(function(error) {
-    self._error = error;
-  })
-};
 
 /*
  * Return the options of the model -- call from an instance of Model
@@ -356,38 +298,6 @@ Model.prototype.getTableName = function() {
 }
 
 
-Model.prototype.fetchIndexes = function() {
-  var self = this;
-
-  return new Promise(function(resolve, reject) {
-    var fetch = function() {
-      var r = self._thinky.r;
-      var query = new Query(self);
-      r.table(self.getTableName()).indexList().do(function(indexes) {
-        return r.table(self.getTableName()).indexWait(r.args(indexes))
-      }).run().then(function(indexes) {
-        for(var i=0; i<indexes.length; i++) {
-          self._getModel()._indexes[indexes[i].index] = true;
-        }
-        self._getModel()._indexesFetched = true;
-
-        if ((self._getModel()._tableCreated === true)
-          && (self._getModel()._indexesToCreate === 0)
-          && (self._getModel()._foreignIndexesToCreate === 0)) {
-
-          self._setReady();
-        }
-
-      }).error(function(error) {
-        self._getModel()._setError(error);
-      });
-
-    }
-
-    self.tableReady().then(fetch);
-  });
-}
-
 Model.prototype.ensureIndex = function(name, fn, opts) {
   var self = this;
 
@@ -395,9 +305,6 @@ Model.prototype.ensureIndex = function(name, fn, opts) {
     opts = fn;
     fn = undefined;
   }
-
-  self._getModel()._indexesToCreate++;
-  self._getModel()._tableReady = false;
 
   return self._createIndex(name, fn, opts)
   .catch(function(error) {
@@ -491,11 +398,6 @@ Model.prototype.hasOne = function(joinedModel, fieldDoc, leftKey, rightKey, opti
 
   options = options || {};
   if (options.init !== false) {
-    joinedModel._getModel()._indexesToCreate++;
-    self._getModel()._foreignIndexesToCreate++;
-
-    self._getModel()._tableReady = false;
-    joinedModel._getModel()._tableReady = false;
     var newIndex = joinedModel._createIndex(rightKey)
     .catch(function(error) {
       joinedModel._getModel()._setError(error);
@@ -546,11 +448,6 @@ Model.prototype.belongsTo = function(joinedModel, fieldDoc, leftKey, rightKey, o
 
   options = options || {};
   if (options.init !== false) {
-    self._getModel()._indexesToCreate++;
-    joinedModel._getModel()._foreignIndexesToCreate++;
-
-    self._getModel()._tableReady = false;
-    joinedModel._getModel()._tableReady = false;
     var newIndex = self._createIndex(leftKey)
     .catch(function(error) {
       joinedModel._getModel()._setError(error);
@@ -594,11 +491,6 @@ Model.prototype.hasMany = function(joinedModel, fieldDoc, leftKey, rightKey, opt
 
   options = options || {};
   if (options.init !== false) {
-    joinedModel._getModel()._indexesToCreate++;
-    self._getModel()._foreignIndexesToCreate++;
-
-    self._getModel()._tableReady = false;
-    joinedModel._getModel()._tableReady = false;
     var newIndex = joinedModel._createIndex(rightKey)
     .catch(function(error) {
       self._getModel()._setError(error);
@@ -674,13 +566,6 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
   if (options.init !== false) {
     var r = self._getModel()._thinky.r;
 
-    self._getModel()._tableReady = false;
-    joinedModel._getModel()._tableReady = false;
-    self._getModel()._indexesToCreate++;
-    joinedModel._getModel()._foreignIndexesToCreate++;
-    joinedModel._getModel()._indexesToCreate++;
-    self._getModel()._foreignIndexesToCreate++;
-
     var query;
     if ((this.getTableName() === joinedModel.getTableName())
       && (leftKey === rightKey)) {
@@ -736,26 +621,16 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
         }
       }
 
-      self._getModel()._foreignIndexesToCreate++;
-      joinedModel._getModel()._foreignIndexesToCreate++;
       return query.run().then(successCb).error(errorCb);
     })
     .then(function() {
       self._createIndex(leftKey)
-      .then(function() {
-        self._indexWasCreated('local');
-        joinedModel._indexWasCreated('foreign');
-      })
       .catch(function(error) {
         self._getModel()._setError(error);
         joinedModel._getModel()._setError(error);
       });
 
       joinedModel._createIndex(rightKey)
-      .then(function() {
-        self._indexWasCreated('foreign');
-        joinedModel._indexWasCreated('local');
-      })
       .catch(function(error) {
         self._getModel()._setError(error);
         joinedModel._getModel()._setError(error);

--- a/lib/query.js
+++ b/lib/query.js
@@ -103,21 +103,8 @@ Query.prototype._execute = function(options, parse) {
   if (self._model._error !== null) {
     return Promise.reject(self._model._error);
   }
-
-  if (self._model._getModel()._tableReady === true) {
+  return self._model.tableReady().then(function() {
     return self._executeCallback(fullOptions, parse, options.groupFormat);
-  }
-
-  return new Promise(function(resolve, reject) {
-    self._model._onTableReady.push(function() {
-      self._executeCallback(fullOptions, parse, options.groupFormat)
-      .then(function(result) {
-        resolve(result);
-      })
-      .catch(function(error) {
-        reject(error);
-      });
-    });
   });
 }
 

--- a/lib/thinky.js
+++ b/lib/thinky.js
@@ -133,32 +133,6 @@ Thinky.prototype.createModel = function(name, schema, options) {
 
   // Keep a reference of this model.
   self.models[name] = model;
-
-  if (fullOptions.init !== false) {
-    // Create the table, or push the table name in the queue.
-    var r = self.r;
-    self.dbReady().then(function() {
-      r.tableList().contains(name).do(function(result) {
-        return r.branch(
-          result,
-          {created: 0},
-          r.tableCreate(name, {primaryKey: model._pk})
-        )
-      }).run().then(function(result) {
-        model._tableWasCreated();
-      }).error(function(error) {
-        model._error = error;
-      })
-    });
-  }
-  else {
-    // We do not initialize the table and suppose that it already exists and
-    // is ready.
-    model._getModel()._tableCreated = true;
-    model.emit('created');
-    model._getModel()._tableReady = true;
-    model.emit('ready');
-  }
   return model;
 }
 

--- a/lib/thinky.js
+++ b/lib/thinky.js
@@ -48,25 +48,11 @@ function Thinky(config) {
   self.Query = Query;
   self.models = {};
 
-  // Whether the database is available or not.
-  self._dbReady = false;
-  // Functions to execute once the database is ready.
-  // We do not use listeners as this used to crash node when too many listeners
-  // were added.
-  self._onDbReady = [];
-
   // Export errors
   self.Errors = Errors;
 
-  // Callback when the database has been created or is available.
-  var onDatabaseReady = function() {
-    for(var i=0; i<self._onDbReady.length; i++) {
-      self._onDbReady[i]();
-    }
-  }
-
   // Initialize the database.
-  self.dbReady().then(onDatabaseReady).error(function(error) {
+  self.dbReady().then().error(function(error) {
     throw error;
   });
 }
@@ -100,9 +86,7 @@ Thinky.prototype.dbReady = function() {
     });
   });
 
-  return self._dbReadyPromise.then(function() {
-    self._dbReady = true;
-  });
+  return self._dbReadyPromise;
 };
 
 /**

--- a/lib/thinky.js
+++ b/lib/thinky.js
@@ -65,25 +65,18 @@ function Thinky(config) {
 Thinky.prototype.dbReady = function() {
   var self = this;
   if (this._dbReadyPromise) return this._dbReadyPromise;
-  this._dbReadyPromise = new Promise(function(resolve, reject) {
-    var r = self.r;
-    r.dbList().contains(self._config.db).do(function(result) {
-      return r.branch(
-        result,
-        {created: 0},
-        r.dbCreate(self._config.db)
-      );
-    }).run().then(resolve).error(function(error) {
-      // The `do` is not atomic, we a concurrent query could create the database
-      // between the time `dbList` is ran and `dbCreate` is.
-      if (error.message.match(/^Database `.*` already exists in/)) {
-        resolve();
-      }
-      else {
-        // In case something went wrong here, we do not recover and throw.
-        reject(error);
-      }
-    });
+  var r = self.r;
+  this._dbReadyPromise = r.dbCreate(self._config.db)
+  .run()
+  .error(function(error) {
+    // The `do` is not atomic, we a concurrent query could create the database
+    // between the time `dbList` is ran and `dbCreate` is.
+    if (error.message.match(/^Database `.*` already exists in/)) {
+      return;
+    }
+
+    // In case something went wrong here, we do not recover and throw.
+    throw error;
   });
 
   return self._dbReadyPromise;

--- a/lib/thinky.js
+++ b/lib/thinky.js
@@ -1,4 +1,5 @@
 var rethinkdbdash = require('rethinkdbdash');
+var Promise = require('bluebird');
 var Model = require(__dirname+'/model.js');
 var util = require(__dirname+'/util.js');
 var type = require(__dirname+'/type/index.js');
@@ -23,6 +24,7 @@ function Thinky(config) {
 
   config = config || {};
   config.db = config.db || 'test'; // We need the default db to create it.
+  self._config = config;
 
   self._options = {};
   // Option passed to each model we are going to create.
@@ -56,32 +58,52 @@ function Thinky(config) {
   // Export errors
   self.Errors = Errors;
 
-  var r = self.r;
   // Callback when the database has been created or is available.
   var onDatabaseReady = function() {
-    self._dbReady = true;
     for(var i=0; i<self._onDbReady.length; i++) {
       self._onDbReady[i]();
     }
   }
-  r.dbList().contains(config.db).do(function(result) {
-    return r.branch(
-      result,
-      {created: 0},
-      r.dbCreate(config.db)
-    )
-  }).run().then(onDatabaseReady).error(function(error) {
-    // The `do` is not atomic, we a concurrent query could create the database
-    // between the time `dbList` is ran and `dbCreate` is.
-    if (error.message.match(/^Database `.*` already exists in/)) {
-      onDatabaseReady();
-    }
-    else {
-      // In case something went wrong here, we do not recover and throw.
-      throw error;
-    }
+
+  // Initialize the database.
+  self.dbReady().then(onDatabaseReady).error(function(error) {
+    throw error;
   });
 }
+
+
+/**
+ * Initialize our database.
+ * @return {Promise=} Returns a promise which will resolve when the database is ready.
+ */
+Thinky.prototype.dbReady = function() {
+  var self = this;
+  if (this._dbReadyPromise) return this._dbReadyPromise;
+  this._dbReadyPromise = new Promise(function(resolve, reject) {
+    var r = self.r;
+    r.dbList().contains(self._config.db).do(function(result) {
+      return r.branch(
+        result,
+        {created: 0},
+        r.dbCreate(self._config.db)
+      );
+    }).run().then(resolve).error(function(error) {
+      // The `do` is not atomic, we a concurrent query could create the database
+      // between the time `dbList` is ran and `dbCreate` is.
+      if (error.message.match(/^Database `.*` already exists in/)) {
+        resolve();
+      }
+      else {
+        // In case something went wrong here, we do not recover and throw.
+        reject(error);
+      }
+    });
+  });
+
+  return self._dbReadyPromise.then(function() {
+    self._dbReady = true;
+  });
+};
 
 /**
  * Return the current option used.

--- a/lib/thinky.js
+++ b/lib/thinky.js
@@ -153,7 +153,7 @@ Thinky.prototype.createModel = function(name, schema, options) {
   if (fullOptions.init !== false) {
     // Create the table, or push the table name in the queue.
     var r = self.r;
-    var onDatabaseReady = function() {
+    self.dbReady().then(function() {
       r.tableList().contains(name).do(function(result) {
         return r.branch(
           result,
@@ -165,13 +165,7 @@ Thinky.prototype.createModel = function(name, schema, options) {
       }).error(function(error) {
         model._error = error;
       })
-    };
-    if (self._dbReady === true) {
-      onDatabaseReady();
-    }
-    else {
-      self._onDbReady.push(onDatabaseReady);
-    }
+    });
   }
   else {
     // We do not initialize the table and suppose that it already exists and


### PR DESCRIPTION
As discussed in #268, moving the table creation code into model.js and making more use of promises would be good for readability and worth the effort. I took a stab at that and went a bit further by eliminating the custom event listener implementations (`onTableCreated` and `onTableReady`) from the file and replaced them with promise based solutions.

I believe model.js should be easier to reason about after these changes. There are more things that could be done (e.g. the `save` and `_parse` functions could use a bit of polishing) but perhaps its best to not do too huge PRs?

A summary of the proposed changes:

* Introduce a `ready()` function which returns a promise that resolves when the Model's table and relations have been successfully created.
* Replace all use of `onTableReady()` and reads of `_tableReady` with `ready()`, both internally and externally.
* Break out index creation to its own function and use it in all relation functions.
* Cleanup.

Some commit messages are admittedly a bit rough around the edges. I'll be happy to clarify any if you find them too brief. Please have a look and tell me if anything looks off.