### PR TITLE
Fix belongsTo() relation foreign key description

### DIFF
--- a/documentation/api/model.md
+++ b/documentation/api/model.md
@@ -209,7 +209,7 @@ Model.belongsTo(OtherModel, fieldName, leftKey, rightKey[, options]);
 ```
 
 Define a "belongs to" relation between two models. The foreign key is
-`leftKey` and will be stored in `OtherModel`.
+`leftKey` and will be stored in `Model`.
 
 If you want to store the foreign key on the joined model, use [hasOne](#hasone).
 


### PR DESCRIPTION
I believe there is a typo in the docs for the `Model.belongsTo` relation. Please check my logic:

The docs state that: 
> Define a "belongs to" relation between two models. The foreign key is `leftKey` and will be stored in `OtherModel`.

I believe it should say `Model`, not `OtherModel`

```js
var Post = thinky.createModel("Post", { // <---- the main "Model"
    id: type.string(),
    title: type.string(),
    content: type.string(),
    authorId: type.string() // <--- foreign/left key in the main "Model"
});

var Author = thinky.createModel("Author", { // <--- the "OtherModel"
    id: type.string(),
    name: type.string()
});

Post.belongsTo(Author, "author", "authorId", "id")
```

The docs for hasOne() correctly state than belongsTo() stores the foreign key in the model creating the relation.
> If you want to store the foreign key on the model creating the relation, use belongsTo.