### PR TITLE
Fix Feeds documentation around deleting of data

### DIFF
--- a/documentation/feeds.md
+++ b/documentation/feeds.md
@@ -70,7 +70,7 @@ Users.changes().then(function(feed) {
 
     if (doc.isSaved() === false) {
       console.log("The following document was deleted:");
-      console.log(stringify(doc.getOldValue()));
+      console.log(stringify(doc));
     }
     else if (doc.getOldValue() == null) {
       console.log("A new document was inserted:");


### PR DESCRIPTION
`doc.getOldValue()` is equal to `null` in this instance. Changing it to just `doc` gives you the correct data that was just deleted.