### PR TITLE
Add custom relations tables. Fixes #282

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Bug report
+
+If you are reporting a bug, please provide the following:
+
+- A *simple* script that one can directly run to reproduce your issue.
+- The full stack trace if there is one (not just the error message).
+- The expected behavior and the one you are seeing.
+
+## Question
+
+If you want to ask a question, please provide as much context as you can. For
+example, if your question is related to relations between models, please
+provide their relations.

--- a/examples/blog/routes/api.js
+++ b/examples/blog/routes/api.js
@@ -199,7 +199,7 @@ exports.deleteComment = function (req, res) {
     var id = req.params.id;
 
     // We can directly delete the comment since there is no foreign key to clean
-    Comment.get(id).delete().run().then(function(error, result) {
+    Comment.get(id).delete().execute().then(function(error, result) {
         res.json({
             error: error,
             result: result

--- a/lib/document.js
+++ b/lib/document.js
@@ -1524,6 +1524,11 @@ Document.prototype._deleteHook = function(docToDelete, deleteAll, deletedDocs, d
       var parents = hasOne[key];
       for(var i=0; i<parents.length; i++) {
         delete parents[i].doc[parents[i].key];
+        util.loopKeys(parents[i].doc.__proto__._hasOne, function(joined, joinKey) {
+          if (joined[joinKey].doc === self) {
+            delete parents[i].doc.__proto__._hasOne[joinKey];
+          }
+        })
       }
     });
     util.loopKeys(self.__proto__._parents._belongsTo, function(belongsTo, key) {
@@ -1541,6 +1546,14 @@ Document.prototype._deleteHook = function(docToDelete, deleteAll, deletedDocs, d
       for(var i=0; i<parents.length; i++) {
         for(var j=0; j<parents[i].doc[parents[i].key].length; j++) {
           if (parents[i].doc[parents[i].key][j] === self) {
+            util.loopKeys(parents[i].doc.__proto__._hasMany, function(joined, joinKey) {
+              for(var k=0; k<joined[joinKey].length; k++) {
+                if (joined[joinKey][k].doc === self) {
+                  joined[joinKey].splice(k, 1);
+                  return false;
+                }
+              }
+            });
             parents[i].doc[parents[i].key].splice(j, 1);
             break;
           }

--- a/lib/document.js
+++ b/lib/document.js
@@ -548,12 +548,26 @@ Document.prototype.__makeSavableCopy = function(doc, schema, options, model, r) 
  * @param {boolean} saveAll Whether _save should recurse by default or not
  * @param {Object=} savedModel Models saved in this call
  * @param {Object=} callback to execute
+ * @param {Object=} LinkModel Specify link model if pivot is present
+ * @param {String=} parentId Parent relation id if pivot is present
  * @return {Promise=}
  */
-Document.prototype._save = function(docToSave, saveAll, savedModel, callback) {
+Document.prototype._save = function(docToSave, saveAll, savedModel, callback, LinkModel, parentId) {
   //TOIMPROVE? How should we handle circular references outsides of joined fields? Now we throw with a maximum call stack size exceed
   var self = this;
   self.emit('saving', self);
+
+  var pivotData = undefined;
+  if (LinkModel) {
+    var pivot = self.pivot;
+    delete self.pivot;
+    pivotData = {
+      parentId: parentId,
+      selfId: self.id,
+      data: pivot,
+      model: LinkModel
+    };
+  }
 
   return util.hook({
     preHooks: self._getModel()._pre.save,
@@ -561,7 +575,7 @@ Document.prototype._save = function(docToSave, saveAll, savedModel, callback) {
     doc: self,
     async: true,
     fn: self._saveHook,
-    fnArgs: [docToSave, saveAll, savedModel]
+    fnArgs: [docToSave, saveAll, savedModel, callback, pivotData]
   }).nodeify(callback);
 }
 
@@ -614,6 +628,7 @@ Document.prototype._batchSaveSelf = function(executeInsert) {
  * @param {Object=} savedModel Models saved in this call
  * @param {Function} resolve The function to call when everything has been saved
  * @param {Function} reject The function to call if an error happened
+ * @param {Object=} pivotData Pivot data if specified
  */
 Document.prototype._saveHook = function(docToSave, saveAll, savedModel) {
   var self = this;
@@ -631,9 +646,17 @@ Document.prototype._saveHook = function(docToSave, saveAll, savedModel) {
   var p = new Promise(function(resolve, reject) {
     // Steps:
     // - Save belongsTo
+    // - Save pivot
     // - Save this
     // - Save hasOne, hasMany and hasAndBelongsToMany docs
     // - Save links
+
+    // Save pivot table
+    var firstPromise;
+    if (pivotData) {
+      var pivot = pivotData.model.get(pivotData.parentId + '_' + pivotData.selfId);
+      firstPromise = pivot.update(pivotData.data);
+    }
 
     // We'll use it to know which `belongsTo` docs were saved
     var belongsToKeysSaved = {};
@@ -642,7 +665,7 @@ Document.prototype._saveHook = function(docToSave, saveAll, savedModel) {
     self._saveVirtual();
 
     // Save the joined documents via belongsTo first
-    var promises = [];
+    var promises = [firstPromise];
     util.loopKeys(model._joins, function(joins, key) {
       if ((docToSave.hasOwnProperty(key) || (saveAll === true)) &&
           (joins[key].type === 'belongsTo') && ((saveAll === false) || (savedModel[joins[key].model.getTableName()] !== true))) {
@@ -971,8 +994,16 @@ Document.prototype._saveMany = function(docToSave, saveAll, savedModel, resolve,
                 if (!(self[key][i] instanceof Document)) {
                   self[key][i] = new joins[key].model(self[key][i]);
                 }
+
+                var LinkModel = undefined;
+                var selfId    = undefined;
+                if (self[key][i].pivot) {
+                  LinkModel = joins[key].linkModel;
+                  selfId = self.id;
+                }
+
                 var callback = function() {
-                  self[key][i]._save(docToSave[key], saveAll, savedModel).then(function() {
+                  self[key][i]._save(docToSave[key], saveAll, savedModel, undefined, LinkModel, selfId).then(function() {
                     // self.__proto__._links will be saved in saveLinks
                     if (self[key][i].__proto__._parents._belongsLinks[self._getModel()._name] == null) {
                       self[key][i].__proto__._parents._belongsLinks[self._getModel()._name] = [];

--- a/lib/document.js
+++ b/lib/document.js
@@ -667,7 +667,15 @@ Document.prototype._saveHook = function(docToSave, saveAll, savedModel, callback
       }).error(reject);
     });
   });
-  return p.nodeify(callback);
+  if (typeof callback === 'function') {
+    return p.then(function(result) {
+      callback(null, result);
+    }).error(function(error) {
+      callback(error, null);
+    })
+  } else {
+    return p
+  }
 }
 
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -380,7 +380,7 @@ Document.prototype.save = function(callback) {
 /**
  * Save the document and its joined documents. It will also execute the hooks.
  * Return a promise if the callback is not provided.
- * It will save joined documents as long as a document of th esame model has not
+ * It will save joined documents as long as a document of the same model has not
  * been saved.
  * @param {function=} callback to execute
  * @return {Promise=}
@@ -403,7 +403,7 @@ Document.prototype.saveAll = function(docToSave, callback) {
 
 /**
  * Return a savable copy of the document by removing the extra fields,
- * generating the dfault and virtual fields.
+ * generating the default and virtual fields.
  * @return {object}
  */
 Document.prototype._makeSavableCopy = function() {

--- a/lib/document.js
+++ b/lib/document.js
@@ -809,7 +809,7 @@ Document.prototype._onSaved = function(result, docToSave, saveAll, savedModel, r
   var self = this;
 
   if (result.first_error != null) {
-    return reject(new Error(result.first_error));
+    return reject(Errors.create(new Error(result.first_error)));
   }
 
   util.tryCatch(function() { // Validate the doc, replace it, and tag it as saved

--- a/lib/document.js
+++ b/lib/document.js
@@ -561,8 +561,8 @@ Document.prototype._save = function(docToSave, saveAll, savedModel, callback) {
     doc: self,
     async: true,
     fn: self._saveHook,
-    fnArgs: [docToSave, saveAll, savedModel, callback]
-  });
+    fnArgs: [docToSave, saveAll, savedModel]
+  }).nodeify(callback);
 }
 
 
@@ -615,7 +615,7 @@ Document.prototype._batchSaveSelf = function(executeInsert) {
  * @param {Function} resolve The function to call when everything has been saved
  * @param {Function} reject The function to call if an error happened
  */
-Document.prototype._saveHook = function(docToSave, saveAll, savedModel, callback) {
+Document.prototype._saveHook = function(docToSave, saveAll, savedModel) {
   var self = this;
   var model = self._getModel(); // instance of Model
   var constructor = self.getModel();
@@ -667,15 +667,7 @@ Document.prototype._saveHook = function(docToSave, saveAll, savedModel, callback
       }).error(reject);
     });
   });
-  if (typeof callback === 'function') {
-    return p.then(function(result) {
-      callback(null, result);
-    }).error(function(error) {
-      callback(error, null);
-    })
-  } else {
-    return p
-  }
+  return p;
 }
 
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -517,8 +517,8 @@ Document.prototype.__makeSavableCopy = function(doc, schema, options, model, r) 
     copyFlag = true;
 
     // Next schema
-    if (Array.isArray(schema)) {
-      nextSchema = schema[0];
+    if (type.isArray(schema)) {
+      nextSchema = schema._schema;
     }
     else if ((util.isPlainObject(schema)) && (schema._type !== undefined) && (schema._schema !== undefined)) {
       nextSchema = schema._schema

--- a/lib/document.js
+++ b/lib/document.js
@@ -575,7 +575,27 @@ Document.prototype._save = function(docToSave, saveAll, savedModel, callback, Li
     doc: self,
     async: true,
     fn: self._saveHook,
-    fnArgs: [docToSave, saveAll, savedModel, callback, pivotData]
+    fnArgs: [docToSave, saveAll, savedModel, pivotData]
+  }).then(function (res) {
+    if (pivotData) {
+      return pivotData.model
+        .run()
+        .then(all => {
+          console.log(all);
+          return pivotData.model
+            .getAll(
+              pivotData.selfId + "_" + pivotData.parentId,
+              pivotData.parentId + "_" + pivotData.selfId
+            )
+            .nth(0)
+            .update(pivotData.data);
+        })
+        .then(() => {
+          return res;
+        })
+    }
+
+    return res;
   }).nodeify(callback);
 }
 
@@ -630,7 +650,7 @@ Document.prototype._batchSaveSelf = function(executeInsert) {
  * @param {Function} reject The function to call if an error happened
  * @param {Object=} pivotData Pivot data if specified
  */
-Document.prototype._saveHook = function(docToSave, saveAll, savedModel) {
+Document.prototype._saveHook = function(docToSave, saveAll, savedModel, pivotData) {
   var self = this;
   var model = self._getModel(); // instance of Model
   var constructor = self.getModel();
@@ -642,21 +662,12 @@ Document.prototype._saveHook = function(docToSave, saveAll, savedModel) {
 
   savedModel[constructor.getTableName()] = true;
 
-
   var p = new Promise(function(resolve, reject) {
     // Steps:
     // - Save belongsTo
-    // - Save pivot
     // - Save this
     // - Save hasOne, hasMany and hasAndBelongsToMany docs
     // - Save links
-
-    // Save pivot table
-    var firstPromise;
-    if (pivotData) {
-      var pivot = pivotData.model.get(pivotData.parentId + '_' + pivotData.selfId);
-      firstPromise = pivot.update(pivotData.data);
-    }
 
     // We'll use it to know which `belongsTo` docs were saved
     var belongsToKeysSaved = {};
@@ -665,7 +676,7 @@ Document.prototype._saveHook = function(docToSave, saveAll, savedModel) {
     self._saveVirtual();
 
     // Save the joined documents via belongsTo first
-    var promises = [firstPromise];
+    var promises = [];
     util.loopKeys(model._joins, function(joins, key) {
       if ((docToSave.hasOwnProperty(key) || (saveAll === true)) &&
           (joins[key].type === 'belongsTo') && ((saveAll === false) || (savedModel[joins[key].model.getTableName()] !== true))) {
@@ -685,9 +696,10 @@ Document.prototype._saveHook = function(docToSave, saveAll, savedModel) {
 
     //TODO Remove once
     self.getModel().ready().then(function() {
-      Promise.all(promises).then(function() {
+      Promise.all(promises)
+      .then(function() {
         self._onSavedBelongsTo(copy, docToSave, belongsToKeysSaved, saveAll, savedModel, resolve, reject);
-      }).error(reject);
+      }).error(reject)
     });
   });
   return p;

--- a/lib/document.js
+++ b/lib/document.js
@@ -1706,6 +1706,14 @@ Document.prototype.purge = function(callback) {
   }).nodeify(callback);
 }
 
+Document.prototype.addRelation = function() {
+  var self = this;
+  var pk = self._getModel()._pk;
+
+  var query = self.getModel().get(this[pk])
+  return query.addRelation.apply(query, arguments);
+}
+
 Document.prototype.removeRelation = function() {
   var self = this;
   var pk = self._getModel()._pk;

--- a/lib/document.js
+++ b/lib/document.js
@@ -575,7 +575,7 @@ Document.prototype._save = function(docToSave, saveAll, savedModel, callback, Li
     doc: self,
     async: true,
     fn: self._saveHook,
-    fnArgs: [docToSave, saveAll, savedModel, pivotData]
+    fnArgs: [docToSave, saveAll, savedModel, callback, pivotData]
   }).then(function (res) {
     if (pivotData) {
       return pivotData.model
@@ -596,7 +596,7 @@ Document.prototype._save = function(docToSave, saveAll, savedModel, callback, Li
     }
 
     return res;
-  }).nodeify(callback);
+  });
 }
 
 
@@ -650,7 +650,7 @@ Document.prototype._batchSaveSelf = function(executeInsert) {
  * @param {Function} reject The function to call if an error happened
  * @param {Object=} pivotData Pivot data if specified
  */
-Document.prototype._saveHook = function(docToSave, saveAll, savedModel, pivotData) {
+Document.prototype._saveHook = function(docToSave, saveAll, savedModel, callback, pivotData) {
   var self = this;
   var model = self._getModel(); // instance of Model
   var constructor = self.getModel();
@@ -665,9 +665,17 @@ Document.prototype._saveHook = function(docToSave, saveAll, savedModel, pivotDat
   var p = new Promise(function(resolve, reject) {
     // Steps:
     // - Save belongsTo
+    // - Save pivot
     // - Save this
     // - Save hasOne, hasMany and hasAndBelongsToMany docs
     // - Save links
+
+    // Save pivot table
+    var firstPromise;
+    if (pivotData) {
+      var pivot = pivotData.model.get(pivotData.parentId + '_' + pivotData.selfId);
+      firstPromise = pivot.update(pivotData.data);
+    }
 
     // We'll use it to know which `belongsTo` docs were saved
     var belongsToKeysSaved = {};
@@ -676,7 +684,7 @@ Document.prototype._saveHook = function(docToSave, saveAll, savedModel, pivotDat
     self._saveVirtual();
 
     // Save the joined documents via belongsTo first
-    var promises = [];
+    var promises = [firstPromise];
     util.loopKeys(model._joins, function(joins, key) {
       if ((docToSave.hasOwnProperty(key) || (saveAll === true)) &&
           (joins[key].type === 'belongsTo') && ((saveAll === false) || (savedModel[joins[key].model.getTableName()] !== true))) {

--- a/lib/document.js
+++ b/lib/document.js
@@ -1482,7 +1482,16 @@ Document.prototype._deleteHook = function(docToDelete, deleteAll, deletedDocs, d
 
           if (self.getModel()._getModel()._pk === joins[key].leftKey) {
             // The table is created since we are deleting an element from it
-            if (self._getModel()._name < joins[key].model._getModel()._name) {
+            if (self._getModel()._name === joins[key].model._getModel()._name) {
+              if (self[joins[key].leftKey] < self[key][i][joins[key].rightKey]) {
+                //TODO Add test for this
+                linksPks.push(self[joins[key].leftKey]+"_"+self[key][i][joins[key].rightKey]);
+              }
+              else {
+                linksPks.push(self[key][i][joins[key].rightKey]+"_"+self[joins[key].leftKey]);
+              }
+            }
+            else if (self._getModel()._name < joins[key].model._getModel()._name) {
               linksPks.push(self[joins[key].leftKey]+"_"+self[key][i][joins[key].rightKey]);
             }
             else {

--- a/lib/document.js
+++ b/lib/document.js
@@ -809,7 +809,7 @@ Document.prototype._onSaved = function(result, docToSave, saveAll, savedModel, r
   var self = this;
 
   if (result.first_error != null) {
-    return reject(Errors.create(new Error(result.first_error)));
+    return reject(Errors.create(result.first_error));
   }
 
   util.tryCatch(function() { // Validate the doc, replace it, and tag it as saved

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,80 +1,86 @@
-var DOCUMENT_NOT_FOUND_REGEX = new RegExp('^The query did not find a document and returned null.*');
-module.exports.DOCUMENT_NOT_FOUND_REGEX = DOCUMENT_NOT_FOUND_REGEX;
-
-var DUPLICATE_PRIMARY_KEY_REGEX = new RegExp('^Duplicate primary key.*');
-module.exports.DUPLICATE_PRIMARY_KEY_REGEX = DUPLICATE_PRIMARY_KEY_REGEX;
-
+"use strict";
+var util = require('util'),
+    errors = module.exports = {};
 
 /**
- * DocumentNotFound error which is returned when `get` returns `null`.
- * "Extends" Error
+ * The base error that all thinky related errors derive from
+ *
+ * @constructor
+ * @alias Error
  */
-function DocumentNotFound(message) {
-  Error.captureStackTrace(this, DocumentNotFound);
-  this.message = message || "The query did not find a document and returned null.";
+errors.ThinkyError = function() {
+  var tmp = Error.apply(this, arguments);
+  tmp.name = this.name = 'ThinkyError';
+
+  this.message = tmp.message;
+  if (Error.captureStackTrace)
+    Error.captureStackTrace(this, this.constructor);
 };
-DocumentNotFound.prototype = Object.create(Error.prototype);
-DocumentNotFound.prototype.constructor = DocumentNotFound;
-DocumentNotFound.prototype.name = "Document not found";
-module.exports.DocumentNotFound = DocumentNotFound;
-
+util.inherits(errors.ThinkyError, Error);
 
 /**
- * InvalidWrite error which is returned when an inplace update/replace return
- * anon valid document.
- * "Extends" Error
+ * Thrown or returned when `get` returns `null`.
+ * @extends ThinkyError
  */
-function InvalidWrite(message, raw) {
-  Error.captureStackTrace(this, InvalidWrite);
-  this.message = message;
+errors.DocumentNotFound = function(message) {
+  message = message || "The query did not find a document and returned null.";
+  errors.ThinkyError.call(this, message);
+  this.name = 'DocumentNotFoundError';
+};
+util.inherits(errors.DocumentNotFound, errors.ThinkyError);
+
+/**
+ * Thrown or returned when an in place update/replace returns an invalid document.
+ * @extends ThinkyError
+ */
+errors.InvalidWrite = function(message, raw) {
+  errors.ThinkyError.call(this, message);
+  this.name = 'InvalidWriteError';
   this.raw = raw;
 };
-InvalidWrite.prototype = Object.create(Error.prototype);
-InvalidWrite.prototype.constructor = InvalidWrite;
-InvalidWrite.prototype.name = "Invalid write";
-module.exports.InvalidWrite = InvalidWrite;
-
+util.inherits(errors.InvalidWrite, errors.ThinkyError);
 
 /**
- * ValidationError error which is returned when validation of a document fails.
- * "Extends" Error
+ * Thrown or returned when validation of a document fails.
+ * @extends ThinkyError
  */
-function ValidationError(message) {
-    Error.captureStackTrace(this, ValidationError);
-    this.message = message;
+errors.ValidationError = function(message) {
+  errors.ThinkyError.call(this, message);
+  this.name = 'ValidationError';
 };
-ValidationError.prototype = Object.create(Error.prototype);
-ValidationError.prototype.constructor = ValidationError;
-ValidationError.prototype.name = "Document failed validation";
-module.exports.ValidationError = ValidationError;
-
+util.inherits(errors.ValidationError, errors.ThinkyError);
 
 /**
- * DuplicatePrimaryKey error which is returned when the primary key unique constraint of a document fails.
- * "Extends" Error
+ * Thrown or returned when the primary key unique document constraint fails.
+ * @extends ThinkyError
  */
-function DuplicatePrimaryKey(message) {
-    Error.captureStackTrace(this, DuplicatePrimaryKey);
-    this.message = message;
+errors.DuplicatePrimaryKey = function(message, primaryKey) {
+  errors.ThinkyError.call(this, message);
+  this.name = 'DuplicatePrimaryKeyError';
+  if (!!primaryKey) this.primaryKey = primaryKey;
 };
-DuplicatePrimaryKey.prototype = new Error();
-DuplicatePrimaryKey.prototype.name = "Duplicate primary key";
-module.exports.DuplicatePrimaryKey = DuplicatePrimaryKey;
+util.inherits(errors.DuplicatePrimaryKey, errors.ThinkyError);
 
+/**
+ * regular expressions used to determine which errors should be thrown
+ */
+errors.DOCUMENT_NOT_FOUND_REGEX = new RegExp('^The query did not find a document and returned null.*');
+errors.DUPLICATE_PRIMARY_KEY_REGEX = new RegExp('^Duplicate primary key `(.*)`.*');
 
-module.exports.create = function (errorOrMessage) {
+/**
+ * Creates an appropriate error given either an instance of Error or a message
+ * from the RethinkDB driver
+ */
+errors.create = function(errorOrMessage) {
   var message = (errorOrMessage instanceof Error) ? errorOrMessage.message : errorOrMessage;
-
-  if(message.match(DOCUMENT_NOT_FOUND_REGEX)) {
-    return new DocumentNotFound(message);
-  }
-
-  if(message.match(DUPLICATE_PRIMARY_KEY_REGEX)) {
-    return new DuplicatePrimaryKey(message);
-  }
-
-  if (errorOrMessage instanceof Error) {
+  if (message.match(errors.DOCUMENT_NOT_FOUND_REGEX)) {
+    return new errors.DocumentNotFound(message);
+  } else if (message.match(errors.DUPLICATE_PRIMARY_KEY_REGEX)) {
+    var primaryKey = message.match(errors.DUPLICATE_PRIMARY_KEY_REGEX)[1];
+    return new errors.DuplicatePrimaryKey(message, primaryKey);
+  } else if (errorOrMessage instanceof Error) {
     return errorOrMessage;
   }
-  return new Error(errorOrMessage);
+
+  return new errors.ThinkyError(errorOrMessage);
 };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -6,7 +6,8 @@ function DocumentNotFound(message) {
   Error.captureStackTrace(this, DocumentNotFound);
   this.message = message || "The query did not find a document and returned null.";
 };
-DocumentNotFound.prototype = new Error();
+DocumentNotFound.prototype = Object.create(Error.prototype);
+DocumentNotFound.prototype.constructor = DocumentNotFound;
 DocumentNotFound.prototype.name = "Document not found";
 module.exports.DocumentNotFound = DocumentNotFound;
 
@@ -21,7 +22,8 @@ function InvalidWrite(message, raw) {
   this.message = message;
   this.raw = raw;
 };
-InvalidWrite.prototype = new Error();
+InvalidWrite.prototype = Object.create(Error.prototype);
+InvalidWrite.prototype.constructor = InvalidWrite;
 InvalidWrite.prototype.name = "Invalid write";
 module.exports.InvalidWrite = InvalidWrite;
 
@@ -34,6 +36,7 @@ function ValidationError(message) {
     Error.captureStackTrace(this, ValidationError);
     this.message = message;
 };
-ValidationError.prototype = new Error();
+ValidationError.prototype = Object.create(Error.prototype);
+ValidationError.prototype.constructor = ValidationError;
 ValidationError.prototype.name = "Document failed validation";
 module.exports.ValidationError = ValidationError;

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -9,6 +9,8 @@ function DocumentNotFound(message) {
 DocumentNotFound.prototype = Object.create(Error.prototype);
 DocumentNotFound.prototype.constructor = DocumentNotFound;
 DocumentNotFound.prototype.name = "Document not found";
+var DocumentNotFoundRegex = new RegExp('^The query did not find a document and returned null.');
+module.exports.DocumentNotFoundRegex = DocumentNotFoundRegex;
 module.exports.DocumentNotFound = DocumentNotFound;
 
 
@@ -40,3 +42,35 @@ ValidationError.prototype = Object.create(Error.prototype);
 ValidationError.prototype.constructor = ValidationError;
 ValidationError.prototype.name = "Document failed validation";
 module.exports.ValidationError = ValidationError;
+
+
+/**
+ * DuplicatePrimaryKey error which is returned when the primary key unique constraint of a document fails.
+ * "Extends" Error
+ */
+function DuplicatePrimaryKey(message) {
+    Error.captureStackTrace(this, DuplicatePrimaryKey);
+    this.message = message;
+};
+DuplicatePrimaryKey.prototype = new Error();
+DuplicatePrimaryKey.prototype.name = "Duplicate primary key";
+var DuplicatePrimaryKeyRegex = new RegExp('^' + DuplicatePrimaryKey.prototype.name);
+module.exports.DuplicatePrimaryKeyRegex = DuplicatePrimaryKeyRegex;
+module.exports.DuplicatePrimaryKey = DuplicatePrimaryKey;
+
+
+module.exports.create = function (error) {
+  if(!(error instanceof Error)) {
+    return error;
+  }
+
+  if(error.message.match(DocumentNotFoundRegex)) {
+    return new DocumentNotFound(error.message);
+  }
+
+  if(error.message.match(DuplicatePrimaryKeyRegex)) {
+    return new DuplicatePrimaryKey(error.message);
+  }
+
+  return error;
+};

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -73,8 +73,8 @@ module.exports.create = function (errorOrMessage) {
     return new DuplicatePrimaryKey(message);
   }
 
-  if (error instanceof Error) {
-    return error;
+  if (errorOrMessage instanceof Error) {
+    return errorOrMessage;
   }
-  return new Error(message);
+  return new Error(errorOrMessage);
 };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,7 @@
 "use strict";
-var util = require('util'),
-    errors = module.exports = {};
+
+var util = require('util');
+var errors = module.exports = {};
 
 /**
  * The base error that all thinky related errors derive from
@@ -23,8 +24,8 @@ util.inherits(errors.ThinkyError, Error);
  * @extends ThinkyError
  */
 errors.DocumentNotFound = function(message) {
-  message = message || "The query did not find a document and returned null.";
-  errors.ThinkyError.call(this, message);
+  var errorMessage = message || "The query did not find a document and returned null.";
+  errors.ThinkyError.call(this, errorMessage);
   this.name = 'DocumentNotFoundError';
 };
 util.inherits(errors.DocumentNotFound, errors.ThinkyError);
@@ -57,7 +58,9 @@ util.inherits(errors.ValidationError, errors.ThinkyError);
 errors.DuplicatePrimaryKey = function(message, primaryKey) {
   errors.ThinkyError.call(this, message);
   this.name = 'DuplicatePrimaryKeyError';
-  if (!!primaryKey) this.primaryKey = primaryKey;
+  if (primaryKey !== undefined) {
+    this.primaryKey = primaryKey;
+  }
 };
 util.inherits(errors.DuplicatePrimaryKey, errors.ThinkyError);
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,3 +1,10 @@
+var DOCUMENT_NOT_FOUND_REGEX = new RegExp('^The query did not find a document and returned null.*');
+module.exports.DOCUMENT_NOT_FOUND_REGEX = DOCUMENT_NOT_FOUND_REGEX;
+
+var DUPLICATE_PRIMARY_KEY_REGEX = new RegExp('^Duplicate primary key.*');
+module.exports.DUPLICATE_PRIMARY_KEY_REGEX = DUPLICATE_PRIMARY_KEY_REGEX;
+
+
 /**
  * DocumentNotFound error which is returned when `get` returns `null`.
  * "Extends" Error
@@ -9,8 +16,6 @@ function DocumentNotFound(message) {
 DocumentNotFound.prototype = Object.create(Error.prototype);
 DocumentNotFound.prototype.constructor = DocumentNotFound;
 DocumentNotFound.prototype.name = "Document not found";
-var DocumentNotFoundRegex = new RegExp('^The query did not find a document and returned null.');
-module.exports.DocumentNotFoundRegex = DocumentNotFoundRegex;
 module.exports.DocumentNotFound = DocumentNotFound;
 
 
@@ -54,23 +59,22 @@ function DuplicatePrimaryKey(message) {
 };
 DuplicatePrimaryKey.prototype = new Error();
 DuplicatePrimaryKey.prototype.name = "Duplicate primary key";
-var DuplicatePrimaryKeyRegex = new RegExp('^' + DuplicatePrimaryKey.prototype.name);
-module.exports.DuplicatePrimaryKeyRegex = DuplicatePrimaryKeyRegex;
 module.exports.DuplicatePrimaryKey = DuplicatePrimaryKey;
 
 
-module.exports.create = function (error) {
-  if(!(error instanceof Error)) {
+module.exports.create = function (errorOrMessage) {
+  var message = (errorOrMessage instanceof Error) ? errorOrMessage.message : errorOrMessage;
+
+  if(message.match(DOCUMENT_NOT_FOUND_REGEX)) {
+    return new DocumentNotFound(message);
+  }
+
+  if(message.match(DUPLICATE_PRIMARY_KEY_REGEX)) {
+    return new DuplicatePrimaryKey(message);
+  }
+
+  if (error instanceof Error) {
     return error;
   }
-
-  if(error.message.match(DocumentNotFoundRegex)) {
-    return new DocumentNotFound(error.message);
-  }
-
-  if(error.message.match(DuplicatePrimaryKeyRegex)) {
-    return new DuplicatePrimaryKey(error.message);
-  }
-
-  return error;
+  return new Error(message);
 };

--- a/lib/model.js
+++ b/lib/model.js
@@ -558,7 +558,9 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
 
   var linkModel;
   if (thinky.models[link] === undefined) {
-    linkModel = thinky.createModel(link, {}); // Create a model, claim the namespace and create the table
+    // Create a model, claim the namespace and create the table
+    // passes table options to the underlying model (e.g. replicas, shards)
+    linkModel = thinky.createModel(link, {}, { table: options.table });
   }
   else {
     linkModel = thinky.models[link];

--- a/lib/model.js
+++ b/lib/model.js
@@ -43,6 +43,9 @@ function Model(name, schema, options, thinky) {
 
   this._pk = (options.pk != null) ? options.pk : 'id';
 
+  this._table = (options.table != null) ? options.table : {};
+  this._table.primaryKey = this._pk;
+
   this._thinky = thinky;
 
   this._validator = options.validator;
@@ -202,7 +205,7 @@ Model.prototype.tableReady = function() {
   var r = model._thinky.r;
   this._tableReadyPromise = model._thinky.dbReady()
   .then(function() {
-    return r.tableCreate(model._name, {primaryKey: model._pk}).run();
+    return r.tableCreate(model._name, model._table).run();
   })
   .error(function(error) {
     if (error.message.match(/Table `.*` already exists/)) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -562,6 +562,9 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
     // passes table options to the underlying model (e.g. replicas, shards)
     linkModel = thinky.createModel(link, {}, { table: options.table });
   }
+  else if (options.through instanceof Model) {
+    linkModel = options.through;
+  }
   else {
     linkModel = thinky.models[link];
   }

--- a/lib/model.js
+++ b/lib/model.js
@@ -143,13 +143,17 @@ Model.new = function(name, schema, options, thinky) {
         postHooks: doc._getModel()._post.init,
         doc: doc,
         async: doc._getModel()._async.init,
-        fn: function() {}
+        fn: function() {
+          return doc;
+        }
       })
       if (promise instanceof Promise) promises.push(promise);
     }
 
     if (promises.length > 0) {
-      return Promise.all(promises);
+      return Promise.all(promises).then(function(docs) {
+        return docs[0];
+      });
     }
     return doc;
   }

--- a/lib/model.js
+++ b/lib/model.js
@@ -128,6 +128,7 @@ Model.new = function(name, schema, options, thinky) {
         }
       }
     });
+    doc._getModel()._schema._setModel(doc._getModel());
     if (proto.needToGenerateFields === true) {
       doc._generateDefault();
     }

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,4 +1,5 @@
 var util = require(__dirname+'/util.js');
+var _util = require('util');
 var schemaUtil = require(__dirname+'/schema.js');
 var Document = require(__dirname+'/document.js');
 var EventEmitter = require('events').EventEmitter;
@@ -82,7 +83,7 @@ function Model(name, schema, options, thinky) {
     validate: []
   };
 }
-util.inherits(Model, EventEmitter);
+_util.inherits(Model, EventEmitter);
 
 Model.new = function(name, schema, options, thinky) {
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -565,6 +565,9 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
   else if (options.through instanceof Model) {
     linkModel = options.through;
   }
+  else if (options.through instanceof Model) {
+    linkModel = options.through;
+  }
   else {
     linkModel = thinky.models[link];
   }

--- a/lib/query.js
+++ b/lib/query.js
@@ -98,6 +98,29 @@ Query.prototype.execute = function(options, callback) {
   return this._execute(options, false).nodeify(callback);
 }
 
+/**
+* Bind Query.prototype.run() for later use
+* @param {Object=} options The options passed to the driver's method `run`
+* @param {Function=} callback
+* @return {Function} return a `this` bound Query.prototype.run()
+*/
+
+Query.prototype.bindRun = function () {
+  var curriedArgs = Array.prototype.slice.call(arguments);
+  return Function.prototype.bind.apply( Query.prototype.run, [ this ].concat( curriedArgs ) );
+}
+
+/**
+ * Bind Query.prototype.execute() for later use
+ * @param {Object=} options The options passed to the driver's method `run`
+ * @param {Function=} callback
+ * @return {Function} return a `this` bound Query.prototype.execute()
+ */
+
+Query.prototype.bindExecute = function () {
+  var curriedArgs = Array.prototype.slice.call(arguments);
+  return Function.prototype.bind.apply( Query.prototype.execute, [ this ].concat( curriedArgs ) );
+}
 
 /**
  * Internal method to execute a query. Called by `run` and `execute`.

--- a/lib/query.js
+++ b/lib/query.js
@@ -563,7 +563,7 @@ Query.prototype.addRelation = function(field, joinedDocument) {
     default:
       return new Query(model, self, {},
           new Error('The provided field `'+field+'` does not store joined documents.')
-      );
+      ).run()
   }
 }
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -115,8 +115,8 @@ Query.prototype._execute = function(options, parse) {
   util.loopKeys(options, function(options, key) {
     fullOptions[key] = options[key]
   });
-  if (parse !== true) {
-    fullOptions.cursor = true;
+  if (parse === true) {
+    fullOptions.cursor = false;
   }
 
   if (self._model._error !== null) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -399,7 +399,11 @@ Query.prototype.getJoin = function(modelToGet, getAll, gotModel) {
                     link(joins[key].leftKey+"_"+joins[key].leftKey).nth(1),
                     link(joins[key].leftKey+"_"+joins[key].leftKey).nth(0)
                   )
-                , {index: joins[key].rightKey})
+                , {index: joins[key].rightKey}).map(function (relatedDoc) {
+                  return relatedDoc.merge({
+                    pivot: link
+                  });
+                })
               });
 
               if ((modelToGet[key] != null) && (typeof modelToGet[key]._apply === 'function')) {
@@ -418,7 +422,11 @@ Query.prototype.getJoin = function(modelToGet, getAll, gotModel) {
             }
             else {
               innerQuery = r.table(joins[key].link).getAll(doc(joins[key].leftKey), {index: model.getTableName()+"_"+joins[key].leftKey}).concatMap(function(link) {
-                return r.table(joins[key].model.getTableName()).getAll(link(joins[key].model.getTableName()+"_"+joins[key].rightKey), {index: joins[key].rightKey})
+                return r.table(joins[key].model.getTableName()).getAll(link(joins[key].model.getTableName()+"_"+joins[key].rightKey), {index: joins[key].rightKey}).map(function (relatedDoc) {
+                  return relatedDoc.merge({
+                    pivot: link
+                  });
+                })
               });
 
               if ((modelToGet[key] != null) && (typeof modelToGet[key]._apply === 'function')) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -393,6 +393,7 @@ Query.prototype.getJoin = function(modelToGet, getAll, gotModel) {
               // In case the model is linked with itself on the same key
 
               innerQuery = r.table(joins[key].link).getAll(doc(joins[key].leftKey), {index: joins[key].leftKey+"_"+joins[key].leftKey}).concatMap(function(link) {
+                console.log('link', link);
                 return r.table(joins[key].model.getTableName()).getAll(
                   r.branch(
                     doc(joins[key].leftKey).eq(link(joins[key].leftKey+"_"+joins[key].leftKey).nth(0)),

--- a/lib/query.js
+++ b/lib/query.js
@@ -197,12 +197,7 @@ Query.prototype._executeCallback = function(fullOptions, parse, groupFormat) {
 
     return result;
   }).catch(function(err) {
-    var notFoundRegex = new RegExp('^' + new Errors.DocumentNotFound().message);
-    if (err.message.match(notFoundRegex)) {
-      //Reject with an instance of Errors.DocumentNotFound
-      err = new Errors.DocumentNotFound(err.message);
-    }
-    return Promise.reject(err);
+    return Promise.reject(Errors.create(err));
   })
 };
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -193,7 +193,6 @@ function parse(schema, prefix, options, model) {
       }
     }
     else if (type.isString(schema)
-        || type.isString(schema)
         || type.isNumber(schema)
         || type.isBoolean(schema)
         || type.isDate(schema)

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -29,7 +29,10 @@ function generateVirtual(doc, defaultField, originalDoc, virtual) {
       }
       else {
         for(var k=0; k<field.length; k++) {
-          generateVirtual(field[k], {path: defaultField.path.slice(j+1), value: defaultField.value}, this, virtual[k]);
+          if (virtual != null) {
+            virtualValue = virtual[k];
+          }
+          generateVirtual(field[k], {path: defaultField.path.slice(j+1), value: defaultField.value}, this, virtualValue);
         }
       }
       keepGoing = false;

--- a/lib/thinky.js
+++ b/lib/thinky.js
@@ -143,3 +143,6 @@ Thinky.prototype._clean = function() {
 module.exports = function(config) {
   return new Thinky(config);
 }
+
+// Expose thinky types directly from module
+module.exports.type = type;

--- a/lib/thinky.js
+++ b/lib/thinky.js
@@ -18,6 +18,7 @@ var Errors = require(__dirname+'/errors.js');
  *  - `enforce_extra` {"strict"|"remove"|"none"}, default `"none"`
  *  - `enforce_type` {"strict"|"loose"|"none"}, default `"loose"`
  *  - `timeFormat` {"raw"|"native"}
+ *  - `createDatabase` {boolean} Whether thinky should create the database or not.
  */
 function Thinky(config) {
   var self = this;
@@ -71,6 +72,9 @@ Thinky.prototype.dbReady = function() {
   var self = this;
   if (this._dbReadyPromise) return this._dbReadyPromise;
   var r = self.r;
+  if (self._config.createDatabase === false) {
+    return Promise.resolve();
+  }
   this._dbReadyPromise = r.dbCreate(self._config.db)
   .run()
   .error(function(error) {

--- a/lib/thinky.js
+++ b/lib/thinky.js
@@ -43,7 +43,12 @@ function Thinky(config) {
   self._options.validate =
     (config.validate != null) ? config.validate : 'onsave';
 
-  self.r = rethinkdbdash(config);
+  if (config.r === undefined) {
+    self.r = rethinkdbdash(config);
+  }
+  else {
+    self.r = config.r;
+  }
   self.type = type;
   self.Query = Query;
   self.models = {};

--- a/lib/type/number.js
+++ b/lib/type/number.js
@@ -2,8 +2,8 @@ var util = require(__dirname+'/../util.js');
 var Errors = require(__dirname+'/../errors.js');
 
 function TypeNumber() {
-  this._min = -1;
-  this._max = -1;
+  this._min = undefined;
+  this._max = undefined;
   this._integer = false;
   this._default = undefined;
   this._validator = undefined;
@@ -63,8 +63,8 @@ TypeNumber.prototype.allowNull = function(value) {
 
 
 TypeNumber.prototype.min = function(min) {
-  if (min < 0) {
-    throw new Errors.ValidationError("The value for `min` must be a positive integer");
+  if ((typeof(min) !== 'number') || (isFinite(min) == false)) {
+    throw new Errors.ValidationError("The value for `min` must be a finite number");
   }
   this._min = min;
   return this;
@@ -72,8 +72,8 @@ TypeNumber.prototype.min = function(min) {
 
 
 TypeNumber.prototype.max = function(max) {
-  if (max < 0) {
-    throw new Errors.ValidationError("The value for `max` must be a positive integer");
+  if ((typeof(max) !== 'number') || (isFinite(max) == false)) {
+    throw new Errors.ValidationError("The value for `max` must be a finite number");
   }
   this._max = max;
   return this;
@@ -128,13 +128,13 @@ TypeNumber.prototype.validate = function(number, prefix, options) {
     }
   }
   else {
-    if ((this._min !== -1) && (this._min > number)){
-      throw new Errors.ValidationError("Value for "+prefix+" must be greater than "+this._min+".")
+    if ((this._min !== undefined) && (this._min > number)){
+      throw new Errors.ValidationError("Value for "+prefix+" must be greater than or equal to "+this._min+".")
     }
-    if ((this._max !== -1) && (this._max < number)){
-      throw new Errors.ValidationError("Value for "+prefix+" must be less than "+this._max+".")
+    if ((this._max !== undefined) && (this._max < number)){
+      throw new Errors.ValidationError("Value for "+prefix+" must be less than or equal to "+this._max+".")
     }
-    if ((this._integer === true) && (number%1 !== 0)){
+    if ((this._integer === true) && (number % 1 !== 0)){
       throw new Errors.ValidationError("Value for "+prefix+" must be an integer.")
     }
   }

--- a/lib/type/string.js
+++ b/lib/type/string.js
@@ -55,6 +55,11 @@ function TypeString() {
    */
   this._default = undefined;
   /**
+   * Whether this string must be a uuid or not.
+   * @type {number}
+   */
+  this._uuid = undefined;
+  /**
    * Options for this type "enforce_missing", "enforce_type", "enforce_extra"
    * @type {Object=}
    */
@@ -251,6 +256,22 @@ TypeString.prototype.default = function(fnOrValue) {
   return this;
 }
 
+/**
+ * Set the string to be a uuid.
+ * @param {number} version
+ * @return {TypeString}
+ */
+TypeString.prototype.uuid = function(version) {
+  if (isNaN(version)) {
+    throw new Errors.ValidationError("The value for `version` must be a number.");
+  }
+  if (version < 3 || version > 5) {
+    throw new Errors.ValidationError("The value for `version` must be either 3, 4 or 5");
+  }
+  this._uuid = version;
+  return this;
+}
+
 
 /**
  * Set a custom validator that will be called with the string. The validator
@@ -342,6 +363,9 @@ TypeString.prototype.validate = function(str, prefix, options) {
     }
     if ((this._uppercase === true) && (validator.isUppercase(str) === false)) {
       throw new Errors.ValidationError("Value for "+prefix+" must be a uppercase string.")
+    }
+    if ((this._uuid !== undefined) && (validator.isUUID(str, this._uuid) === false)) {
+      throw new Errors.ValidationError("Value for "+prefix+" must be a uuid string.")
     }
     if ((this._enum !== undefined) && (this._enum[str] !== true)) {
       var validValues = Object.keys(this._enum);

--- a/lib/type/string.js
+++ b/lib/type/string.js
@@ -341,10 +341,10 @@ TypeString.prototype.validate = function(str, prefix, options) {
   }
   else {
     if ((this._min !== -1) && (this._min > str.length)){
-      throw new Errors.ValidationError("Value for "+prefix+" must be longer than "+this._min+".")
+      throw new Errors.ValidationError("Value for "+prefix+" must not be shorter than "+this._min+".")
     }
     if ((this._max !== -1) && (this._max < str.length)){
-      throw new Errors.ValidationError("Value for "+prefix+" must be shorter than "+this._max+".")
+      throw new Errors.ValidationError("Value for "+prefix+" must not be longer than "+this._max+".")
     }
     if ((this._length !== -1) && (this._length !== str.length)){
       throw new Errors.ValidationError("Value for "+prefix+" must be a string with "+this._length+" characters.")

--- a/lib/util.js
+++ b/lib/util.js
@@ -183,7 +183,7 @@ function executeHooks(hookIndex, hooks, doc, reject, next) {
       });
     }
     else {
-      hooks[hookIndex](doc);
+      hooks[hookIndex].call(doc);
       executeHooks(hookIndex+1, hooks, doc, reject, next)
     }
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,4 +1,4 @@
-var util = require('util');
+var util = {};
 var Promise = require('bluebird');
 var EventEmitter = require('events').EventEmitter;
 var Errors = require(__dirname+'/errors.js');

--- a/lib/util.js
+++ b/lib/util.js
@@ -299,8 +299,7 @@ function pseudoTypeError(type, missingField, prefix) {
 util.pseudoTypeError = pseudoTypeError;
 
 
-// Return true if doc is undefined or null, else false
-// Can throw
+// Return true if doc is undefined, else false
 function validateIfUndefined(value, prefix, type, options) {
   if (value === undefined) {
     if (options.enforce_missing === true) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies":{
     "rethinkdbdash": "^2.2.15",
-    "bluebird": "~2.1.3",
+    "bluebird": "~2.10.2",
     "validator": "~ 3.22.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.2.7",
+  "version": "2.3.0",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {
@@ -24,7 +24,7 @@
     "url": "https://github.com/neumino/thinky/issues"
   },
   "dependencies":{
-    "rethinkdbdash": "^2.2.15",
+    "rethinkdbdash": "^2.3.0",
     "bluebird": "~2.10.2",
     "validator": "~ 3.22.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.1.12",
+  "version": "2.2.0",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {
@@ -24,7 +24,7 @@
     "url": "https://github.com/neumino/thinky/issues"
   },
   "dependencies":{
-    "rethinkdbdash": "~2.1.8",
+    "rethinkdbdash": "~2.2.0",
     "bluebird": "~2.1.3",
     "validator": "~ 3.22.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/neumino/thinky/issues"
   },
   "dependencies":{
-    "rethinkdbdash": "~2.1.1",
+    "rethinkdbdash": "~2.1.8",
     "bluebird": "~2.1.3",
     "validator": "~ 3.22.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/neumino/thinky/issues"
   },
   "dependencies":{
-    "rethinkdbdash": "^2.3.0",
+    "rethinkdbdash": "~2.3.0",
     "bluebird": "~2.10.2",
     "validator": "~ 3.22.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/neumino/thinky/issues"
   },
   "dependencies":{
-    "rethinkdbdash": "~2.2.0",
+    "rethinkdbdash": "^2.2.15",
     "bluebird": "~2.1.3",
     "validator": "~ 3.22.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {
@@ -26,7 +26,7 @@
   "dependencies":{
     "rethinkdbdash": "~2.3.0",
     "bluebird": "~2.10.2",
-    "validator": "~ 3.22.1"
+    "validator": "~3.22.1"
   },
   "devDependencies": {
     "mocha": "~1.21.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {

--- a/test/advanced.js
+++ b/test/advanced.js
@@ -3037,8 +3037,6 @@ describe('Advanced cases', function(){
 
       Promise.all(promises).then(function() {
         return Model.innerJoin(OtherModel.between(r.minval, r.maxval)._query, function() { return true}).execute()
-      }).then(function(cursor) {
-        return cursor.toArray();
       }).then(function(result) {
         assert.equal(result.length, 3);
         assert.deepEqual(result[0].left, doc);

--- a/test/advanced.js
+++ b/test/advanced.js
@@ -471,7 +471,7 @@ describe('Advanced cases', function(){
         assert.equal(true, resultM1.linksOM[0].pivot !== undefined);
         assert.equal("foo", resultM1.linksOM[0].pivot.extra);
         done();
-      })
+      });
     });
     it('hasAndBelongsToMany -- custom pivot tables with the same table', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -502,7 +502,41 @@ describe('Advanced cases', function(){
         assert.equal(true, resultM1.linksM[0].pivot !== undefined);
         assert.equal("foo", resultM1.linksM[0].pivot.extra);
         done();
-      })
+      });
+    });
+    it('hasAndBelongsToMany -- inset pivot table', function (done) {
+      var Model = thinky.createModel(modelNames[0], {
+        id: String
+      });
+
+      var OtherModel = thinky.createModel(modelNames[1], {
+        id: String
+      });
+
+      var LinkMOM = thinky.createModel(modelNames[0] + '_' + modelNames[1], {
+        id: String,
+        extra: String
+      });
+
+      Model.hasAndBelongsToMany(OtherModel, "linksOM", "id", "id", { through: LinkMOM });
+      OtherModel.hasAndBelongsToMany(Model, "linksM", "id", "id", { through: LinkMOM });
+
+      var m1 = new Model({ id: 'm1' });
+      var om1 = new OtherModel({ id: 'om1', pivot: { extra: 'foo' } });
+
+      m1.linksOM = [ om1 ];
+
+      om1.save().then(function () {
+        return m1.saveAll({ linksOM: true });
+      }).then(function () {
+        return Model.get("m1").getJoin({ linksOM: true });
+      }).then(function (resultM1) {
+        assert.equal(true, resultM1.linksOM !== undefined);
+        assert.equal(1, resultM1.linksOM.length);
+        assert.equal(true, resultM1.linksOM[0].pivot !== undefined);
+        assert.equal("foo", resultM1.linksOM[0].pivot.extra);
+        done();
+      });
     });
     it('hasAndBelongsToMany -- primary keys', function(done) {
       var Model = thinky.createModel(modelNames[0], {

--- a/test/advanced.js
+++ b/test/advanced.js
@@ -469,11 +469,8 @@ describe('Advanced cases', function(){
         assert.equal(true, resultM1.linksOM !== undefined);
         assert.equal(1, resultM1.linksOM.length);
         assert.equal(true, resultM1.linksOM[0].pivot !== undefined);
-        console.log(resultM1.linksOM[0]);
         assert.equal("foo", resultM1.linksOM[0].pivot.extra);
         done();
-      }).catch(function (err) {
-        console.log('ERR', err);
       })
     });
     it('hasAndBelongsToMany -- custom pivot tables with the same table', function(done) {

--- a/test/advanced.js
+++ b/test/advanced.js
@@ -478,7 +478,7 @@ describe('Advanced cases', function(){
         id: String
       });
 
-      var LinkMM = thinky.createModel(modelNames[0] + '_' + modelNames[1], {
+      var LinkMM = thinky.createModel(modelNames[0] + '_' + modelNames[0], {
         id: String,
         extra: String
       });
@@ -504,7 +504,7 @@ describe('Advanced cases', function(){
         done();
       });
     });
-    it('hasAndBelongsToMany -- inset pivot table', function (done) {
+    it('hasAndBelongsToMany -- insert pivot table', function (done) {
       var Model = thinky.createModel(modelNames[0], {
         id: String
       });
@@ -531,6 +531,7 @@ describe('Advanced cases', function(){
       }).then(function () {
         return Model.get("m1").getJoin({ linksOM: true });
       }).then(function (resultM1) {
+        console.log('RESULT');
         assert.equal(true, resultM1.linksOM !== undefined);
         assert.equal(1, resultM1.linksOM.length);
         assert.equal(true, resultM1.linksOM[0].pivot !== undefined);
@@ -2417,7 +2418,7 @@ describe('Advanced cases', function(){
       doc1.saveAll({links: true}).then(function(result) {
         return Model.get(doc1.id).getJoin({links: true}).run()
       }).then(function(result) {
-        assert.deepEqual(result.links[0], doc2);
+        assert.equal(result.links[0].id, doc2.id);
         done();
       }).error(done);
     });

--- a/test/document.js
+++ b/test/document.js
@@ -2949,6 +2949,24 @@ describe('hooks', function() {
       });
     }).error(done);
   });
+  it('save pre - with error and callback', function(done) {
+    var Model = thinky.createModel(modelNames[0], {id: String, title: String});
+
+    Model.pre('save', function(next) {
+      var self = this;
+      setTimeout(function() {
+        next(new Error("foo"));
+      }, 1);
+    })
+
+    var doc = new Model({id: "foo"});
+    doc.save(function(err) {
+      assert(err instanceof Error);
+      assert.equal(err.message, "foo");
+      done();
+    })
+  });
+
   it('save pre - sync', function(done) {
     var Model = thinky.createModel(modelNames[0], {id: String, title: String});
 

--- a/test/document.js
+++ b/test/document.js
@@ -2947,6 +2947,25 @@ describe('hooks', function() {
       });
     }).error(done);
   });
+  it('save pre - sync', function(done) {
+    var Model = thinky.createModel(modelNames[0], {id: String, title: String});
+
+    Model.pre('save', function() {
+      console.log("HELLO",this);
+      this.title = this.id;
+    })
+
+    var doc = new Model({id: "foo"});
+    doc.save().then(function(result) {
+      assert.strictEqual(result, doc)
+      assert.equal(doc.id, doc.title);
+      r.table(Model.getTableName()).get(doc.id).run().then(function(result) {
+        assert.equal(result.id, result.title);
+        done();
+      });
+    }).error(done);
+  });
+
   it('save post', function(done) {
     var Model = thinky.createModel(modelNames[0], {id: String, title: String});
 
@@ -3214,4 +3233,3 @@ describe('removeRelation', function(){
     });
   });
 });
-

--- a/test/document.js
+++ b/test/document.js
@@ -307,6 +307,32 @@ describe('save', function() {
         done()
       }).error(done)
     });
+    it('Date as string should be coerced to ReQL dates in array', function(done){
+      var Model = thinky.createModel(modelNames[0], {
+        id: String,
+        array: type.array().schema({
+          date: Date
+        })
+      })
+      var t = new Model({
+        id: util.s8(),
+        array: [{
+          date: (new Date()).toISOString()
+        }]
+      });
+
+      t.save().then(function(result) {
+        assert(t.array[0].date instanceof Date)
+        assert.equal(t.array[0].date.getYear(), new Date().getYear());
+
+        return Model.get(t.id).execute({timeFormat: "raw"})
+      }).then(function(result) {
+        assert.equal(Object.prototype.toString.call(result.array[0].date), "[object Object]");
+        assert.equal(result.array[0].date.$reql_type$, "TIME");
+        done()
+      }).error(done)
+    });
+
     it('Date as number should be coerced to ReQL dates', function(done){
       var Model = thinky.createModel(modelNames[0], {
         id: String,

--- a/test/document.js
+++ b/test/document.js
@@ -106,7 +106,7 @@ describe('save', function() {
           done(new Error("Expecting error"))
         }).error(function (err) {
           assert(err instanceof Errors.DuplicatePrimaryKey);
-          assert(err.message.match(Errors.DOCUMENT_NOT_FOUND_REGEX));
+          assert(err.message.match(Errors.DUPLICATE_PRIMARY_KEY_REGEX));
           done();
         });
       }).error(done);

--- a/test/document.js
+++ b/test/document.js
@@ -104,8 +104,9 @@ describe('save', function() {
         })
         doc2.save().then(function(r) {
           done(new Error("Expecting error"))
-        }).error(function(error) {
-          assert(error.message.match(/^Duplicate primary key/));
+        }).error(function (err) {
+          assert(err instanceof Errors.DuplicatePrimaryKey);
+          assert(err.message.match(Errors.DuplicatePrimaryKeyRegex));
           done();
         });
       }).error(done);
@@ -2890,7 +2891,7 @@ describe('hooks', function() {
         self.title = self.id;
         next();
       }, 1);
-    })
+    });
 
     Model.once('ready', function() {
       r.table(Model.getTableName()).insert({id: 1}).run().then(function(result) {

--- a/test/document.js
+++ b/test/document.js
@@ -106,7 +106,7 @@ describe('save', function() {
           done(new Error("Expecting error"))
         }).error(function (err) {
           assert(err instanceof Errors.DuplicatePrimaryKey);
-          assert(err.message.match(Errors.DuplicatePrimaryKeyRegex));
+          assert(err.message.match(Errors.DOCUMENT_NOT_FOUND_REGEX));
           done();
         });
       }).error(done);

--- a/test/document.js
+++ b/test/document.js
@@ -107,6 +107,7 @@ describe('save', function() {
         }).error(function (err) {
           assert(err instanceof Errors.DuplicatePrimaryKey);
           assert(err.message.match(Errors.DUPLICATE_PRIMARY_KEY_REGEX));
+          assert.equal(err.primaryKey, 'id');
           done();
         });
       }).error(done);

--- a/test/feed.js
+++ b/test/feed.js
@@ -126,7 +126,7 @@ describe('Atom feeds', function() {
   });
 
   it('get().changes() should work - and remove default(r.error)', function(done){
-    Model.get(1).changes().run().then(function(doc) {
+    Model.get(1).changes({includeInitial: true}).run().then(function(doc) {
       assert(doc)
       assert.deepEqual(doc, {});
       return doc.closeFeed();
@@ -137,7 +137,7 @@ describe('Atom feeds', function() {
 
   it('change events should be emitted - insert', function(done){
     var data = {id: 'foo', str: 'bar', num: 3};
-    Model.get(data.id).changes().run().then(function(doc) {
+    Model.get(data.id).changes({includeInitial: true}).run().then(function(doc) {
       assert(doc)
       assert.deepEqual(doc, {});
       doc.on('change', function() {
@@ -153,7 +153,7 @@ describe('Atom feeds', function() {
   it('change events should be emitted - update', function(done){
     var data = {id: 'buzz', str: 'bar', num: 3};
     Model.save(data).then(function() {
-      Model.get(data.id).changes().run().then(function(doc) {
+      Model.get(data.id).changes({includeInitial: true}).run().then(function(doc) {
         assert.deepEqual(doc, data);
         doc.on('change', function() {
           assert.deepEqual(doc.getOldValue(), data);
@@ -169,7 +169,7 @@ describe('Atom feeds', function() {
   it('change events should be emitted - delete', function(done){
     var data = {id: 'bar', str: 'bar', num: 3};
     Model.save(data).then(function() {
-      Model.get(data.id).changes().run().then(function(doc) {
+      Model.get(data.id).changes({includeInitial: true}).run().then(function(doc) {
         assert.deepEqual(doc, data);
         doc.on('change', function() {
           assert.deepEqual(doc.getOldValue(), data);
@@ -186,7 +186,7 @@ describe('Atom feeds', function() {
   });
   it('change events should be emitted - all', function(done){
     var data = {id: 'last', str: 'bar', num: 3};
-    Model.get(data.id).changes().run().then(function(doc) {
+    Model.get(data.id).changes({includeInitial: true}).run().then(function(doc) {
       assert(doc)
       assert.deepEqual(doc, {});
       var count = 0;

--- a/test/model.js
+++ b/test/model.js
@@ -869,4 +869,26 @@ describe('virtual', function(){
     assert.equal(doc.ar, 3);
   });
 
+  it('Virtual fields should work in nested arrays', function() {
+    var Model = thinky.createModel(modelNames[0], {
+      nested : [
+        {
+          foo: String,
+          bar: type.virtual().default(function() {
+            return "buzz";
+          })
+        }
+      ]
+    });
+    var doc = new Model({
+      nested : [
+        {
+          foo: 'hello'
+        }
+      ]
+    });
+
+    assert.equal(doc.nested[0].bar, 'buzz');
+  });
+
 });

--- a/test/query.js
+++ b/test/query.js
@@ -1891,7 +1891,6 @@ describe.only('Functional Utilities', function () {
 
       doc.save().then(function(){
         Model.get(doc.id).run(function (err, instance1) {
-          console.log(err);
           bound(function (err, instance2){
             assert(instance2.id == instance1.id);
             done()

--- a/test/query.js
+++ b/test/query.js
@@ -2,6 +2,7 @@ var config = require(__dirname+'/../config.js');
 var thinky = require(__dirname+'/../lib/thinky.js')(config);
 var r = thinky.r;
 var Document = require(__dirname+'/../lib/document.js');
+var Errors = require(__dirname+'/../lib/errors.js');
 
 var util = require(__dirname+'/util.js');
 var assert = require('assert');
@@ -11,8 +12,6 @@ var modelNameSet = {};
 modelNameSet[util.s8()] = true;
 modelNameSet[util.s8()] = true;
 var modelNames = Object.keys(modelNameSet);
-
-var documentNotFoundRegex = new RegExp('^' + new thinky.Errors.DocumentNotFound().message);
 
 var cleanTables = function(done) {
   var promises = [];
@@ -155,7 +154,7 @@ describe('Model queries', function() {
     Model.get("NonExistingKey").merge({foo: "bar"}).run().then(function(result) {
       done(new Error("Was expecting an error"));
     }).error(function(error) {
-      assert(error.message.match(documentNotFoundRegex));
+      assert(error.message.match(Errors.DocumentNotFoundRegex));
       done();
     });
   });
@@ -1316,7 +1315,7 @@ describe('Query.run() should take options', function(){
     Model.get(0).run().then(function() {
       done(new Error("Was expecting an error"))
     }).catch(Errors.DocumentNotFound, function(err) {
-      assert(err.message.match(documentNotFoundRegex));
+      assert(err.message.match(Errors.DocumentNotFoundRegex));
       done();
     }).error(function() {
       done(new Error("Not the expected error"))
@@ -1328,7 +1327,7 @@ describe('Query.run() should take options', function(){
       done(new Error("Was expecting an error"))
     }).error(function(err) {
       assert(err instanceof Errors.DocumentNotFound);
-      assert(err.message.match(documentNotFoundRegex));
+      assert(err.message.match(Errors.DocumentNotFoundRegex));
       done();
     });
   });
@@ -1798,7 +1797,7 @@ describe('In place writes', function() {
       num: Number
     });
     Model.get('nonExistingId').update({foo: 'bar'}).run().error(function(error) {
-      assert(documentNotFoundRegex.test(error.message));
+      assert(Errors.DocumentNotFoundRegex.test(error.message));
       done();
     });
   })

--- a/test/query.js
+++ b/test/query.js
@@ -260,31 +260,25 @@ describe('Model queries', function() {
     }).error(done);
   });
   it('Model.execute should not return instances of the model', function(done){
-    Model.execute().then(function(cursor) {
-      cursor.toArray().then(function(result) {
-        assert(!(result[0] instanceof Document));
-        assert.equal(result.length, 3);
-        done();
-      });
+    Model.execute().then(function(result) {
+      assert(!(result[0] instanceof Document));
+      assert.equal(result.length, 3);
+      done();
     }).error(done);
   });
   it('Model.execute should work with a callback', function(done){
-    Model.execute(function(err, cursor) {
-      cursor.toArray().then(function(result) {
-        assert(!(result[0] instanceof Document));
-        assert.equal(result.length, 3);
-        done();
-      });
+    Model.execute(function(err, result) {
+      assert(!(result[0] instanceof Document));
+      assert.equal(result.length, 3);
+      done();
     }).error(done);
   });
 
   it('Model.map(1).execute should work', function(done){
-    Model.map(function() { return 1 }).execute().then(function(cursor) {
-      cursor.toArray().then(function(result) {
-        assert(!(result[0] instanceof Document));
-        assert.equal(result.length, 3);
-        done();
-      })
+    Model.map(function() { return 1 }).execute().then(function(result) {
+      assert(!(result[0] instanceof Document));
+      assert.equal(result.length, 3);
+      done();
     }).error(done);
   });
   it('Model.add(1).execute() should be able to error', function(done){

--- a/test/query.js
+++ b/test/query.js
@@ -1822,9 +1822,6 @@ describe('In place writes', function() {
     });
   });
 
-describe.only('Functional Utilities', function () {
-
-
   describe('Query.prototype.bindRun()', function () {
 
     it('handles Promises', function (done) {
@@ -1900,6 +1897,5 @@ describe.only('Functional Utilities', function () {
     });
 
   });
-});
   
 });

--- a/test/query.js
+++ b/test/query.js
@@ -154,7 +154,7 @@ describe('Model queries', function() {
     Model.get("NonExistingKey").merge({foo: "bar"}).run().then(function(result) {
       done(new Error("Was expecting an error"));
     }).error(function(error) {
-      assert(error.message.match(Errors.DocumentNotFoundRegex));
+      assert(error.message.match(Errors.DOCUMENT_NOT_FOUND_REGEX));
       done();
     });
   });
@@ -1315,7 +1315,7 @@ describe('Query.run() should take options', function(){
     Model.get(0).run().then(function() {
       done(new Error("Was expecting an error"))
     }).catch(Errors.DocumentNotFound, function(err) {
-      assert(err.message.match(Errors.DocumentNotFoundRegex));
+      assert(err.message.match(Errors.DOCUMENT_NOT_FOUND_REGEX));
       done();
     }).error(function() {
       done(new Error("Not the expected error"))
@@ -1327,7 +1327,7 @@ describe('Query.run() should take options', function(){
       done(new Error("Was expecting an error"))
     }).error(function(err) {
       assert(err instanceof Errors.DocumentNotFound);
-      assert(err.message.match(Errors.DocumentNotFoundRegex));
+      assert(err.message.match(Errors.DOCUMENT_NOT_FOUND_REGEX));
       done();
     });
   });
@@ -1797,7 +1797,7 @@ describe('In place writes', function() {
       num: Number
     });
     Model.get('nonExistingId').update({foo: 'bar'}).run().error(function(error) {
-      assert(Errors.DocumentNotFoundRegex.test(error.message));
+      assert(Errors.DOCUMENT_NOT_FOUND_REGEX.test(error.message));
       done();
     });
   })

--- a/test/query.js
+++ b/test/query.js
@@ -605,6 +605,7 @@ describe('getJoin', function(){
       Model.get(doc.id).getJoin().run().then(function(result) {
         util.sortById(result.otherDocs);
 
+        console.log(doc, result);
         assert.deepEqual(doc, result);
         assert(result.isSaved());
         for(var i=0; i<result.otherDocs.length; i++) {

--- a/test/query.js
+++ b/test/query.js
@@ -1822,4 +1822,86 @@ describe('In place writes', function() {
       assert(total !== undefined);
     });
   });
+
+describe.only('Functional Utilities', function () {
+
+
+  describe('Query.prototype.bindRun()', function () {
+
+    it('handles Promises', function (done) {
+      var Model = thinky.createModel(modelNames[0], {id: String});
+    
+      var doc = new Model({id: util.s8(), num: 0});
+      var bound = Model.get(doc.id).bindRun();
+
+      doc.save().then(function(){
+        Model.get(doc.id).then(function(instance1){
+          util.passThru(bound).then(function(instance2){
+            assert(instance2.id == instance1.id);
+            done()
+          });
+        });
+      });
+
+    });
+
+    it('handles node-style callbacks', function (done) {
+      var Model = thinky.createModel(modelNames[0], {id: String});
+    
+      var doc = new Model({id: util.s8(), num: 0});
+      var bound = Model.get(doc.id).bindRun();
+
+      doc.save().then(function(){
+        Model.get(doc.id).run(function (err, instance1) {
+          bound(function (err, instance2){
+            assert(instance2.id == instance1.id);
+            done()
+          });
+        });
+      });
+
+    });
+
+  });
+
+  describe('Query.prototype.bindExecute()', function () {
+
+    it('handles Promises', function (done) {
+      var Model = thinky.createModel(modelNames[0], {id: String});
+    
+      var doc = new Model({id: util.s8(), num: 0});
+      var bound = Model.get(doc.id).bindExecute();
+
+      doc.save().then(function(){
+        Model.get(doc.id).then(function(instance1){
+          util.passThru(bound).then(function(instance2){
+            assert(instance2.id == instance1.id);
+            done()
+          });
+        });
+      });
+
+    });
+
+    it('handles node-style callbacks', function (done) {
+      var Model = thinky.createModel(modelNames[0], {id: String});
+    
+      var doc = new Model({id: util.s8(), num: 0});
+      var bound = Model.get(doc.id).bindExecute();
+
+      doc.save().then(function(){
+        Model.get(doc.id).run(function (err, instance1) {
+          console.log(err);
+          bound(function (err, instance2){
+            assert(instance2.id == instance1.id);
+            done()
+          });
+        });
+      });
+
+    });
+
+  });
+});
+  
 });

--- a/test/query.js
+++ b/test/query.js
@@ -392,6 +392,124 @@ describe('getJoin', function(){
       }).error(done);
     })
   })
+  describe("Joins - hasMany with allowExtra(false)", function() {
+    var Model, OtherModel, doc;
+    before(function(done) {
+      var name = util.s8();
+      Model = thinky.createModel(modelNames[0], thinky.type.object().schema({
+        id: thinky.type.string(),
+        str: thinky.type.string(),
+        num: thinky.type.number()
+      }).allowExtra(false));
+
+      var otherName = util.s8();
+      OtherModel = thinky.createModel(modelNames[1], {
+        id: String,
+        str: String,
+        num: Number,
+        foreignKey: String
+      });
+      Model.hasMany(OtherModel, "otherDocs", "id", "foreignKey")
+
+      var docValues = {str: util.s8(), num: util.random()}
+      doc = new Model(docValues);
+      var otherDocs = [new OtherModel({str: util.s8(), num: util.random()}), new OtherModel({str: util.s8(), num: util.random()}), new OtherModel({str: util.s8(), num: util.random()})];
+      doc.otherDocs = otherDocs;
+
+      doc.saveAll().then(function(doc) {
+        util.sortById(doc.otherDocs);
+        done();
+      }).error(done);
+
+    });
+
+    after(cleanTables);
+
+    it('should retrieve joined documents with object', function(done) {
+      Model.get(doc.id).getJoin().run().then(function(result) {
+        util.sortById(result.otherDocs);
+
+        assert.deepEqual(doc, result);
+        assert(result.isSaved());
+        for(var i=0; i<result.otherDocs.length; i++) {
+          assert.equal(result.otherDocs[i].isSaved(), true);
+        }
+        done()
+      }).error(done);
+    })
+    it('should retrieve joined documents with sequence', function(done) {
+      Model.filter({id: doc.id}).getJoin().run().then(function(result) {
+        util.sortById(result[0].otherDocs);
+
+        assert.deepEqual([doc], result);
+        assert(result[0].isSaved());
+        for(var i=0; i<result[0].otherDocs.length; i++) {
+          assert.equal(result[0].otherDocs[i].isSaved(), true);
+        }
+
+        done()
+      }).error(done);
+    })
+  })
+  describe("Joins - hasMany with removeExtra()", function() {
+    var Model, OtherModel, doc;
+    before(function(done) {
+      var name = util.s8();
+      Model = thinky.createModel(modelNames[0], thinky.type.object().schema({
+        id: thinky.type.string(),
+        str: thinky.type.string(),
+        num: thinky.type.number()
+      }).removeExtra());
+
+      var otherName = util.s8();
+      OtherModel = thinky.createModel(modelNames[1], {
+        id: String,
+        str: String,
+        num: Number,
+        foreignKey: String
+      });
+      Model.hasMany(OtherModel, "otherDocs", "id", "foreignKey")
+
+      var docValues = {str: util.s8(), num: util.random()}
+      doc = new Model(docValues);
+      var otherDocs = [new OtherModel({str: util.s8(), num: util.random()}), new OtherModel({str: util.s8(), num: util.random()}), new OtherModel({str: util.s8(), num: util.random()})];
+      doc.otherDocs = otherDocs;
+
+      doc.saveAll().then(function(doc) {
+        util.sortById(doc.otherDocs);
+        done();
+      }).error(done);
+
+    });
+
+    after(cleanTables);
+
+    it('should retrieve joined documents with object', function(done) {
+      Model.get(doc.id).getJoin().run().then(function(result) {
+        util.sortById(result.otherDocs);
+
+        assert.deepEqual(doc, result);
+        assert(result.isSaved());
+        for(var i=0; i<result.otherDocs.length; i++) {
+          assert.equal(result.otherDocs[i].isSaved(), true);
+        }
+        done()
+      }).error(done);
+    })
+    it('should retrieve joined documents with sequence', function(done) {
+      Model.filter({id: doc.id}).getJoin().run().then(function(result) {
+        util.sortById(result[0].otherDocs);
+
+        assert.deepEqual([doc], result);
+        assert(result[0].isSaved());
+        for(var i=0; i<result[0].otherDocs.length; i++) {
+          assert.equal(result[0].otherDocs[i].isSaved(), true);
+        }
+
+        done()
+      }).error(done);
+    })
+  })
   describe("Joins - hasMany", function() {
     var Model, OtherModel, doc;
     before(function(done) {

--- a/test/schema.js
+++ b/test/schema.js
@@ -453,6 +453,48 @@ describe('Chainable types', function(){
     var doc = new Model({ id: 'FOOBAR'});
     doc.validate();
   });
+  it('String - uuid - not uuid v3', function (){
+    var name = util.s8();
+    var Model = thinky.createModel(name,
+      {id: type.string().uuid(3) },
+      {init: false})
+    var doc = new Model({id: "xxxA987FBC9-4BED-3078-CF07-9141BA07C9F3"})
+  });
+  it('String - uuid - is uuid v3', function (){
+    var name = util.s8();
+    var Model = thinky.createModel(name,
+      {id: type.string().uuid(3) },
+      {init: false})
+    var doc = new Model({id: "A987FBC9-4BED-3078-CF07-9141BA07C9F3"})
+  });
+  it('String - uuid - not uuid v4', function (){
+    var name = util.s8();
+    var Model = thinky.createModel(name,
+      {id: type.string().uuid(4) },
+      {init: false})
+    var doc = new Model({id: "A987FBC9-4BED-5078-AF07-9141BA07C9F3"})
+  });
+  it('String - uuid - is uuid v4', function (){
+    var name = util.s8();
+    var Model = thinky.createModel(name,
+      {id: type.string().uuid(4) },
+      {init: false})
+    var doc = new Model({id: "713ae7e3-cb32-45f9-adcb-7c4fa86b90c1"})
+  });
+  it('String - uuid - not uuid v5', function (){
+    var name = util.s8();
+    var Model = thinky.createModel(name,
+      {id: type.string().uuid(5) },
+      {init: false})
+    var doc = new Model({id: "9c858901-8a57-4791-81fe-4c455b099bc9"})
+  });
+  it('String - uuid - is uuid v5', function (){
+    var name = util.s8();
+    var Model = thinky.createModel(name,
+      {id: type.string().uuid(5) },
+      {init: false})
+    var doc = new Model({id: "987FBC97-4BED-5078-BF07-9141BA07C9F3"})
+  });
   it('String - validator - return false', function(){
     var name = util.s8();
     var Model = thinky.createModel(name,

--- a/test/schema.js
+++ b/test/schema.js
@@ -681,8 +681,16 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 1});
       doc.validate();
     }, function(error) {
-      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be greater than 2.");
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be greater than or equal to 2.");
     });
+  });
+  it('Number - min - negative', function(){
+    var name = util.s8();
+    var Model = thinky.createModel(name,
+      {id: type.number().min(-2) },
+      {init: false})
+    var doc = new Model({ id: -1});
+    doc.validate();
   });
   it('Number - min - good', function(){
     var name = util.s8();
@@ -690,6 +698,14 @@ describe('Chainable types', function(){
       {id: type.number().min(2) },
       {init: false})
     var doc = new Model({ id: 3});
+    doc.validate();
+  });
+  it('Number - min - just right', function(){
+    var name = util.s8();
+    var Model = thinky.createModel(name,
+      {id: type.number().min(2) },
+      {init: false})
+    var doc = new Model({ id: 2});
     doc.validate();
   });
   it('Number - max - too big', function(){
@@ -701,8 +717,16 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 8});
       doc.validate();
     }, function(error) {
-      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be less than 5.");
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be less than or equal to 5.");
     });
+  });
+  it('Number - max - negative', function(){
+    var name = util.s8();
+    var Model = thinky.createModel(name,
+      {id: type.number().max(-5) },
+      {init: false})
+    var doc = new Model({ id: -8});
+    doc.validate();
   });
   it('Number - max - good', function(){
     var name = util.s8();
@@ -710,6 +734,14 @@ describe('Chainable types', function(){
       {id: type.number().max(5) },
       {init: false})
     var doc = new Model({ id: 3});
+    doc.validate();
+  });
+  it('Number - max - just right', function(){
+    var name = util.s8();
+    var Model = thinky.createModel(name,
+      {id: type.number().max(5) },
+      {init: false})
+    var doc = new Model({ id: 5});
     doc.validate();
   });
   it('Number - integer - float', function(){

--- a/test/schema.js
+++ b/test/schema.js
@@ -268,7 +268,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 'a'});
       doc.validate();
     }, function(error) {
-      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be longer than 2.");
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must not be shorter than 2.");
     });
   });
   it('String - min - good', function(){
@@ -288,7 +288,7 @@ describe('Chainable types', function(){
       var doc = new Model({ id: 'abcdefgh'});
       doc.validate();
     }, function(error) {
-      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be shorter than 5.");
+      return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must not be longer than 5.");
     });
   });
   it('String - max - good', function(){

--- a/test/settings.js
+++ b/test/settings.js
@@ -74,6 +74,20 @@ describe('Options', function(){
       });
     });
   });
+  it('table option on a model', function(done){
+    var name = util.s8();
+    var Model = thinky.createModel(name, {id: String, name: String}, {
+      table: {
+        durability: 'soft'
+      }
+    });
+    Model.once('ready', function() {
+      r.table(Model.getTableName()).config().run().then(function(result) {
+        assert.equal(result.durability, 'soft');
+        done();
+      });
+    });
+  });
   it('Options on a document', function(){
     var name = util.s8();
     var Model = thinky.createModel(name, {id: String, name: String});

--- a/test/util.js
+++ b/test/util.js
@@ -72,3 +72,9 @@ function log(value) {
   console.log(JSON.stringify(value, null, 2));
 }
 module.exports.log = log;
+
+// pseudo computational chain helper
+function passThru (fn) {
+  return fn();
+}
+module.exports.passThru = passThru;


### PR DESCRIPTION
Adopted syntax :

``` js
var thinky = require('thinky')();

var A = thinky.createModel('A', {id: String});
var B = thinky.createModel('B', {id: String});
var A_B = thinky.createModel('A_B', {id: String, extra: String});
var A_A = thinky.createModel('A_A', {id: String, extra: String});
A.hasAndBelongsToMany(B, 'bs', 'id', 'id', { through: A_B });
B.hasAndBelongsToMany(A, 'as', 'id', 'id', { through: A_B });

A.hasAndBelongsToMany(A, 'as', 'id', 'id', { through: A_A });

A.delete().then(function () {
    return B.delete();
}).then(function () {
    var a = new A({id: 'a1'});
    a.bs = [new B({id: 'b1'})];
    a.as = [new A({id: 'a2'})];

    return a.saveAll({ bs: true, as: true });
}).then(function () {
    // Stash some extra fields on the link.
    return A_B.get('a1_b1').update({extra: '42'});
}).then(function () {
    // Stash some extra fields on the link.
    return A_A.get('a1_a2').update({extra: '42'});
}).then(function () {
    return A.get('a1').getJoin({bs: true, as: true });
}).then(function (r) {
    console.log(r.bs[0]);
    console.log(r.as[0]);
    process.exit(0);
});
```

Missing form this PR : version push, documentation
