### PR TITLE
added duplicate primary key error

### DIFF
--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptLibraryMappings">
+    <file url="file://$PROJECT_DIR$" libraries="{thinky node_modules}" />
+  </component>
+</project>

--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="JavaScriptLibraryMappings">
-    <file url="file://$PROJECT_DIR$" libraries="{thinky node_modules}" />
-  </component>
-</project>

--- a/lib/document.js
+++ b/lib/document.js
@@ -809,7 +809,7 @@ Document.prototype._onSaved = function(result, docToSave, saveAll, savedModel, r
   var self = this;
 
   if (result.first_error != null) {
-    return reject(Errors.create(result.first_error));
+    return reject(Errors.create(new Error(result)));
   }
 
   util.tryCatch(function() { // Validate the doc, replace it, and tag it as saved

--- a/lib/document.js
+++ b/lib/document.js
@@ -809,6 +809,12 @@ Document.prototype._onSaved = function(result, docToSave, saveAll, savedModel, r
   var self = this;
 
   if (result.first_error != null) {
+    var duplicatePrimaryKeyRegex = new RegExp('^' + new Errors.DuplicatePrimaryKey().name);
+    if(result.first_error.match(duplicatePrimaryKeyRegex)) {
+      //Reject with an instance of Errors.DuplicatePrimaryKeyError
+      return reject(new Errors.DuplicatePrimaryKey (result.first_error));
+    }
+
     return reject(new Error(result.first_error));
   }
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -809,7 +809,7 @@ Document.prototype._onSaved = function(result, docToSave, saveAll, savedModel, r
   var self = this;
 
   if (result.first_error != null) {
-    return reject(Errors.create(new Error(result)));
+    return reject(Errors.create(new Error(result.first_error)));
   }
 
   util.tryCatch(function() { // Validate the doc, replace it, and tag it as saved

--- a/lib/document.js
+++ b/lib/document.js
@@ -809,13 +809,7 @@ Document.prototype._onSaved = function(result, docToSave, saveAll, savedModel, r
   var self = this;
 
   if (result.first_error != null) {
-    var duplicatePrimaryKeyRegex = new RegExp('^' + new Errors.DuplicatePrimaryKey().name);
-    if(result.first_error.match(duplicatePrimaryKeyRegex)) {
-      //Reject with an instance of Errors.DuplicatePrimaryKeyError
-      return reject(new Errors.DuplicatePrimaryKey (result.first_error));
-    }
-
-    return reject(new Error(result.first_error));
+    return reject(Errors.create(result.first_error));
   }
 
   util.tryCatch(function() { // Validate the doc, replace it, and tag it as saved

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -37,3 +37,16 @@ function ValidationError(message) {
 ValidationError.prototype = new Error();
 ValidationError.prototype.name = "Document failed validation";
 module.exports.ValidationError = ValidationError;
+
+
+/**
+ * DuplicatePrimaryKey error which is returned when the primary key unique constraint of a document fails.
+ * "Extends" Error
+ */
+function DuplicatePrimaryKey(message) {
+    Error.captureStackTrace(this, DuplicatePrimaryKey);
+    this.message = message;
+};
+DuplicatePrimaryKey.prototype = new Error();
+DuplicatePrimaryKey.prototype.name = "Duplicate primary key";
+module.exports.DuplicatePrimaryKey = DuplicatePrimaryKey;

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,3 +1,7 @@
+function createRegex(error) {
+  new RegExp('^' + error.name);
+}
+
 /**
  * DocumentNotFound error which is returned when `get` returns `null`.
  * "Extends" Error
@@ -8,6 +12,8 @@ function DocumentNotFound(message) {
 };
 DocumentNotFound.prototype = new Error();
 DocumentNotFound.prototype.name = "Document not found";
+var DocumentNotFoundRegex = new RegExp('^' + DocumentNotFound.prototype.name);
+module.exports.DocumentNotFoundRegex = DocumentNotFoundRegex;
 module.exports.DocumentNotFound = DocumentNotFound;
 
 
@@ -23,6 +29,8 @@ function InvalidWrite(message, raw) {
 };
 InvalidWrite.prototype = new Error();
 InvalidWrite.prototype.name = "Invalid write";
+var InvalidWriteRegex = new RegExp('^' + InvalidWrite.prototype.name);
+module.exports.InvalidWriteRegex = InvalidWriteRegex;
 module.exports.InvalidWrite = InvalidWrite;
 
 
@@ -36,6 +44,8 @@ function ValidationError(message) {
 };
 ValidationError.prototype = new Error();
 ValidationError.prototype.name = "Document failed validation";
+var ValidationErrorRegex = new RegExp('^' + ValidationError.prototype.name);
+module.exports.ValidationErrorRegex = ValidationErrorRegex;
 module.exports.ValidationError = ValidationError;
 
 
@@ -49,16 +59,28 @@ function DuplicatePrimaryKey(message) {
 };
 DuplicatePrimaryKey.prototype = new Error();
 DuplicatePrimaryKey.prototype.name = "Duplicate primary key";
+var DuplicatePrimaryKeyRegex = new RegExp('^' + DuplicatePrimaryKey.prototype.name);
+module.exports.DuplicatePrimaryKeyRegex = DuplicatePrimaryKeyRegex;
 module.exports.DuplicatePrimaryKey = DuplicatePrimaryKey;
 
 
 module.exports.create = function (message) {
-  for(var key in module.exports) {
-    if(module.exports[key].prototype instanceof Error) {
-      var regex = new RegExp('^' + new module.exports[key]().name);
-      if(message.match(regex))
-        return new module.exports[key](message);
-    }
+  if(message.match(DocumentNotFoundRegex)) {
+    return new DocumentNotFound(message);
   }
+
+  if(message.match(InvalidWriteRegex)) {
+    return new InvalidWrite(message);
+  }
+
+  if(message.match(ValidationErrorRegex)) {
+    return new ValidationError(message);
+  }
+
+
+  if(message.match(DuplicatePrimaryKeyRegex)) {
+    return new DuplicatePrimaryKey(message);
+  }
+
   return new Error(message);
 };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -65,7 +65,7 @@ module.exports.create = function (error) {
     return new DocumentNotFound(error.message);
   }
 
-  if(message.match(DuplicatePrimaryKeyRegex)) {
+  if(error.message.match(DuplicatePrimaryKeyRegex)) {
     return new DuplicatePrimaryKey(error.message);
   }
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -7,8 +7,8 @@ function DocumentNotFound(message) {
   this.message = message || "The query did not find a document and returned null.";
 };
 DocumentNotFound.prototype = new Error();
-DocumentNotFound.prototype.name = "The query did not find a document";
-var DocumentNotFoundRegex = new RegExp('^' + DocumentNotFound.prototype.name);
+DocumentNotFound.prototype.name = "Document not found";
+var DocumentNotFoundRegex = new RegExp('^The query did not find a document and returned null.');
 module.exports.DocumentNotFoundRegex = DocumentNotFoundRegex;
 module.exports.DocumentNotFound = DocumentNotFound;
 
@@ -25,8 +25,6 @@ function InvalidWrite(message, raw) {
 };
 InvalidWrite.prototype = new Error();
 InvalidWrite.prototype.name = "Invalid write";
-var InvalidWriteRegex = new RegExp('^' + InvalidWrite.prototype.name);
-module.exports.InvalidWriteRegex = InvalidWriteRegex;
 module.exports.InvalidWrite = InvalidWrite;
 
 
@@ -40,8 +38,6 @@ function ValidationError(message) {
 };
 ValidationError.prototype = new Error();
 ValidationError.prototype.name = "Document failed validation";
-var ValidationErrorRegex = new RegExp('^' + ValidationError.prototype.name);
-module.exports.ValidationErrorRegex = ValidationErrorRegex;
 module.exports.ValidationError = ValidationError;
 
 
@@ -60,23 +56,27 @@ module.exports.DuplicatePrimaryKeyRegex = DuplicatePrimaryKeyRegex;
 module.exports.DuplicatePrimaryKey = DuplicatePrimaryKey;
 
 
-module.exports.create = function (message) {
-  if(message.match(DocumentNotFoundRegex)) {
-    return new DocumentNotFound(message);
+module.exports.create = function (error) {
+  if(!(error instanceof Error)) {
+    return error;
   }
 
-  if(message.match(InvalidWriteRegex)) {
-    return new InvalidWrite(message);
+  if(error.message.match(DocumentNotFoundRegex)) {
+    return new DocumentNotFound(error.message);
+  }
+
+  if(error.message.match(InvalidWriteRegex)) {
+    return new InvalidWrite(error.message);
   }
 
   if(message.match(ValidationErrorRegex)) {
-    return new ValidationError(message);
+    return new ValidationError(error.message);
   }
 
 
   if(message.match(DuplicatePrimaryKeyRegex)) {
-    return new DuplicatePrimaryKey(message);
+    return new DuplicatePrimaryKey(error.message);
   }
 
-  return new Error(message);
+  return error;
 };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -60,6 +60,5 @@ module.exports.create = function (message) {
         return new module.exports[key](message);
     }
   }
-
   return new Error(message);
 };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -50,3 +50,16 @@ function DuplicatePrimaryKey(message) {
 DuplicatePrimaryKey.prototype = new Error();
 DuplicatePrimaryKey.prototype.name = "Duplicate primary key";
 module.exports.DuplicatePrimaryKey = DuplicatePrimaryKey;
+
+
+module.exports.create = function (message) {
+  for(var key in module.exports) {
+    if(module.exports[key] instanceof Error) {
+      var regex = new RegExp('^' + new module.exports[key].name);
+      if(message.match(regex))
+        return new module.exports[key](message);
+    }
+  }
+
+  return new Error(message);
+};

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -65,15 +65,6 @@ module.exports.create = function (error) {
     return new DocumentNotFound(error.message);
   }
 
-  if(error.message.match(InvalidWriteRegex)) {
-    return new InvalidWrite(error.message);
-  }
-
-  if(message.match(ValidationErrorRegex)) {
-    return new ValidationError(error.message);
-  }
-
-
   if(message.match(DuplicatePrimaryKeyRegex)) {
     return new DuplicatePrimaryKey(error.message);
   }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -54,8 +54,8 @@ module.exports.DuplicatePrimaryKey = DuplicatePrimaryKey;
 
 module.exports.create = function (message) {
   for(var key in module.exports) {
-    if(module.exports[key] instanceof Error) {
-      var regex = new RegExp('^' + new module.exports[key].name);
+    if(module.exports[key].prototype instanceof Error) {
+      var regex = new RegExp('^' + new module.exports[key]().name);
       if(message.match(regex))
         return new module.exports[key](message);
     }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,7 +1,3 @@
-function createRegex(error) {
-  new RegExp('^' + error.name);
-}
-
 /**
  * DocumentNotFound error which is returned when `get` returns `null`.
  * "Extends" Error
@@ -11,7 +7,7 @@ function DocumentNotFound(message) {
   this.message = message || "The query did not find a document and returned null.";
 };
 DocumentNotFound.prototype = new Error();
-DocumentNotFound.prototype.name = "Document not found";
+DocumentNotFound.prototype.name = "The query did not find a document";
 var DocumentNotFoundRegex = new RegExp('^' + DocumentNotFound.prototype.name);
 module.exports.DocumentNotFoundRegex = DocumentNotFoundRegex;
 module.exports.DocumentNotFound = DocumentNotFound;

--- a/lib/query.js
+++ b/lib/query.js
@@ -174,12 +174,7 @@ Query.prototype._executeCallback = function(fullOptions, parse, groupFormat) {
 
     return result;
   }).catch(function(err) {
-    var notFoundRegex = new RegExp('^' + new Errors.DocumentNotFound().message);
-    if (err.message.match(notFoundRegex)) {
-      //Reject with an instance of Errors.DocumentNotFound
-      err = new Errors.DocumentNotFound(err.message);
-    }
-    return Promise.reject(err);
+    return Promise.reject(Errors.create(err.message));
   })
 };
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -174,7 +174,7 @@ Query.prototype._executeCallback = function(fullOptions, parse, groupFormat) {
 
     return result;
   }).catch(function(err) {
-    return Promise.reject(Errors.create(err.message));
+    return Promise.reject(Errors.create(err));
   })
 };
 

--- a/test/document.js
+++ b/test/document.js
@@ -2891,7 +2891,7 @@ describe('hooks', function() {
         self.title = self.id;
         next();
       }, 1);
-    })
+    });
 
     Model.once('ready', function() {
       r.table(Model.getTableName()).insert({id: 1}).run().then(function(result) {

--- a/test/document.js
+++ b/test/document.js
@@ -17,8 +17,6 @@ modelNameSet[util.s8()] = true;
 modelNameSet[util.s8()] = true;
 var modelNames = Object.keys(modelNameSet);
 
-var duplicatePrimaryKeyRegex = new RegExp('^' + new thinky.Errors.DuplicatePrimaryKey().name);
-
 var cleanTables = function(done) {
   var promises = [];
   var name;
@@ -108,7 +106,7 @@ describe('save', function() {
           done(new Error("Expecting error"))
         }).error(function (err) {
           assert(err instanceof Errors.DuplicatePrimaryKey);
-          assert(err.message.match(duplicatePrimaryKeyRegex));
+          assert(err.message.match(Errors.DuplicatePrimaryKeyRegex));
           done();
         });
       }).error(done);

--- a/test/document.js
+++ b/test/document.js
@@ -17,6 +17,8 @@ modelNameSet[util.s8()] = true;
 modelNameSet[util.s8()] = true;
 var modelNames = Object.keys(modelNameSet);
 
+var duplicatePrimaryKeyRegex = new RegExp('^' + new thinky.Errors.DuplicatePrimaryKey().name);
+
 var cleanTables = function(done) {
   var promises = [];
   var name;
@@ -104,8 +106,9 @@ describe('save', function() {
         })
         doc2.save().then(function(r) {
           done(new Error("Expecting error"))
-        }).error(function(error) {
-          assert(error.message.match(/^Duplicate primary key/));
+        }).error(function (err) {
+          assert(err instanceof Errors.DuplicatePrimaryKey);
+          assert(err.message.match(duplicatePrimaryKeyRegex));
           done();
         });
       }).error(done);

--- a/test/query.js
+++ b/test/query.js
@@ -12,8 +12,6 @@ modelNameSet[util.s8()] = true;
 modelNameSet[util.s8()] = true;
 var modelNames = Object.keys(modelNameSet);
 
-var documentNotFoundRegex = new RegExp('^' + new thinky.Errors.DocumentNotFound().message);
-
 var cleanTables = function(done) {
   var promises = [];
   var name;
@@ -155,7 +153,7 @@ describe('Model queries', function() {
     Model.get("NonExistingKey").merge({foo: "bar"}).run().then(function(result) {
       done(new Error("Was expecting an error"));
     }).error(function(error) {
-      assert(error.message.match(documentNotFoundRegex));
+      assert(error.message.match(Errors.DocumentNotFoundRegex));
       done();
     });
   });

--- a/test/query.js
+++ b/test/query.js
@@ -1315,7 +1315,7 @@ describe('Query.run() should take options', function(){
     Model.get(0).run().then(function() {
       done(new Error("Was expecting an error"))
     }).catch(Errors.DocumentNotFound, function(err) {
-      assert(err.message.match(Errors.DuplicatePrimaryKeyRegex));
+      assert(err.message.match(Errors.DocumentNotFoundRegex));
       done();
     }).error(function() {
       done(new Error("Not the expected error"))
@@ -1327,7 +1327,7 @@ describe('Query.run() should take options', function(){
       done(new Error("Was expecting an error"))
     }).error(function(err) {
       assert(err instanceof Errors.DocumentNotFound);
-      assert(err.message.match(Errors.DuplicatePrimaryKeyRegex));
+      assert(err.message.match(Errors.DocumentNotFoundRegex));
       done();
     });
   });
@@ -1797,7 +1797,7 @@ describe('In place writes', function() {
       num: Number
     });
     Model.get('nonExistingId').update({foo: 'bar'}).run().error(function(error) {
-      assert(Errors.DuplicatePrimaryKeyRegex.test(error.message));
+      assert(Errors.DocumentNotFoundRegex.test(error.message));
       done();
     });
   })

--- a/test/query.js
+++ b/test/query.js
@@ -2,6 +2,7 @@ var config = require(__dirname+'/../config.js');
 var thinky = require(__dirname+'/../lib/thinky.js')(config);
 var r = thinky.r;
 var Document = require(__dirname+'/../lib/document.js');
+var Errors = require(__dirname+'/../lib/errors.js');
 
 var util = require(__dirname+'/util.js');
 var assert = require('assert');
@@ -1314,7 +1315,7 @@ describe('Query.run() should take options', function(){
     Model.get(0).run().then(function() {
       done(new Error("Was expecting an error"))
     }).catch(Errors.DocumentNotFound, function(err) {
-      assert(err.message.match(documentNotFoundRegex));
+      assert(err.message.match(Errors.DuplicatePrimaryKeyRegex));
       done();
     }).error(function() {
       done(new Error("Not the expected error"))
@@ -1326,7 +1327,7 @@ describe('Query.run() should take options', function(){
       done(new Error("Was expecting an error"))
     }).error(function(err) {
       assert(err instanceof Errors.DocumentNotFound);
-      assert(err.message.match(documentNotFoundRegex));
+      assert(err.message.match(Errors.DuplicatePrimaryKeyRegex));
       done();
     });
   });
@@ -1796,7 +1797,7 @@ describe('In place writes', function() {
       num: Number
     });
     Model.get('nonExistingId').update({foo: 'bar'}).run().error(function(error) {
-      assert(documentNotFoundRegex.test(error.message));
+      assert(Errors.DuplicatePrimaryKeyRegex.test(error.message));
       done();
     });
   })


### PR DESCRIPTION
allows to catch duplicate primary keys
```
document.save()
	.then(function(r) {
		...
    })
    .catch(Errors.DuplicatePrimaryKey, function () {
        ...
    })
    .error(function (err) {
    	...
    });
```