### PR TITLE
add Query.prototype.bind()

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -99,12 +99,27 @@ Query.prototype.execute = function(options, callback) {
 }
 
 /**
-* Bind a Query for later use
-* @return {Function} return a bound run
+* Bind Query.prototype.run() for later use
+* @param {Object=} options The options passed to the driver's method `run`
+* @param {Function=} callback
+* @return {Function} return a `this` bound Query.prototype.run()
 */
 
-Query.prototype.bind = function () {
-  return this.run.bind(this);
+Query.prototype.bindRun = function () {
+  var curriedArgs = Array.prototype.slice.call(arguments);
+  return Function.prototype.bind.apply( Query.prototype.run, [ this ].concat( curriedArgs ) );
+}
+
+/**
+ * Bind Query.prototype.execute() for later use
+ * @param {Object=} options The options passed to the driver's method `run`
+ * @param {Function=} callback
+ * @return {Function} return a `this` bound Query.prototype.execute()
+ */
+
+Query.prototype.bindExecute = function () {
+  var curriedArgs = Array.prototype.slice.call(arguments);
+  return Function.prototype.bind.apply( Query.prototype.execute, [ this ].concat( curriedArgs ) );
 }
 
 /**

--- a/lib/query.js
+++ b/lib/query.js
@@ -98,6 +98,14 @@ Query.prototype.execute = function(options, callback) {
   return this._execute(options, false).nodeify(callback);
 }
 
+/**
+* Bind a Query for later use
+* @return {Function} return a bound run
+*/
+
+Query.prototype.bind = function () {
+  return this.run.bind(this);
+}
 
 /**
  * Internal method to execute a query. Called by `run` and `execute`.

--- a/test/query.js
+++ b/test/query.js
@@ -1823,20 +1823,82 @@ describe('In place writes', function() {
     });
   });
 
-describe('Functional Utilities', function () {
-  it('should provide chainable interface to bind runs for later execution', function (done) {
-    var Model = thinky.createModel(modelNames[0], {id: String});
-    
-    var doc = new Model({id: util.s8(), num: 0});
-    var bound = Model.get(doc.id).bind();
+describe.only('Functional Utilities', function () {
 
-    doc.save().then(function(){
-      Model.get(doc.id).then(function(instance1){
-        bound().then(function(instance2){
-          assert(instance2.id == instance1.id);
-          done()
+
+  describe('Query.prototype.bindRun()', function () {
+
+    it('handles Promises', function (done) {
+      var Model = thinky.createModel(modelNames[0], {id: String});
+    
+      var doc = new Model({id: util.s8(), num: 0});
+      var bound = Model.get(doc.id).bindRun();
+
+      doc.save().then(function(){
+        Model.get(doc.id).then(function(instance1){
+          util.passThru(bound).then(function(instance2){
+            assert(instance2.id == instance1.id);
+            done()
+          });
         });
       });
+
+    });
+
+    it('handles node-style callbacks', function (done) {
+      var Model = thinky.createModel(modelNames[0], {id: String});
+    
+      var doc = new Model({id: util.s8(), num: 0});
+      var bound = Model.get(doc.id).bindRun();
+
+      doc.save().then(function(){
+        Model.get(doc.id).run(function (err, instance1) {
+          bound(function (err, instance2){
+            assert(instance2.id == instance1.id);
+            done()
+          });
+        });
+      });
+
+    });
+
+  });
+
+  describe('Query.prototype.bindExecute()', function () {
+
+    it('handles Promises', function (done) {
+      var Model = thinky.createModel(modelNames[0], {id: String});
+    
+      var doc = new Model({id: util.s8(), num: 0});
+      var bound = Model.get(doc.id).bindExecute();
+
+      doc.save().then(function(){
+        Model.get(doc.id).then(function(instance1){
+          util.passThru(bound).then(function(instance2){
+            assert(instance2.id == instance1.id);
+            done()
+          });
+        });
+      });
+
+    });
+
+    it('handles node-style callbacks', function (done) {
+      var Model = thinky.createModel(modelNames[0], {id: String});
+    
+      var doc = new Model({id: util.s8(), num: 0});
+      var bound = Model.get(doc.id).bindExecute();
+
+      doc.save().then(function(){
+        Model.get(doc.id).run(function (err, instance1) {
+          console.log(err);
+          bound(function (err, instance2){
+            assert(instance2.id == instance1.id);
+            done()
+          });
+        });
+      });
+
     });
 
   });

--- a/test/query.js
+++ b/test/query.js
@@ -1822,4 +1822,24 @@ describe('In place writes', function() {
       assert(total !== undefined);
     });
   });
+
+describe('Functional Utilities', function () {
+  it('should provide chainable interface to bind runs for later execution', function (done) {
+    var Model = thinky.createModel(modelNames[0], {id: String});
+    
+    var doc = new Model({id: util.s8(), num: 0});
+    var bound = Model.get(doc.id).bind();
+
+    doc.save().then(function(){
+      Model.get(doc.id).then(function(instance1){
+        bound().then(function(instance2){
+          assert(instance2.id == instance1.id);
+          done()
+        });
+      });
+    });
+
+  });
+});
+  
 });

--- a/test/util.js
+++ b/test/util.js
@@ -72,3 +72,9 @@ function log(value) {
   console.log(JSON.stringify(value, null, 2));
 }
 module.exports.log = log;
+
+// pseudo computational chain helper
+function passThru (fn) {
+  return fn();
+}
+module.exports.passThru = passThru;


### PR DESCRIPTION
I often find that when I am using Thinky with some sort of functional library in a computational chain, one of two things happens.

I end up with a lot of models looking like this:
```js
var User = thinky.createModel("User", {
    id: type.number(),
    age: type.number(),
    admin: type.boolean().default(false)
});

User.defineStatic('bind', function() {
  return this.run.bind(this);
});
```

Or I end up creating some extraneous lines of code:

```js
query = User.find(req.params.id);
boundQuery = query.run.bind(query);
```

It seemed like a useful addition to make thinky play more nicely with functional libraries that handle promises (like Ramda.js for instance).