### PR TITLE
Fix Errors prototype chain

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -6,7 +6,8 @@ function DocumentNotFound(message) {
   Error.captureStackTrace(this, DocumentNotFound);
   this.message = message || "The query did not find a document and returned null.";
 };
-DocumentNotFound.prototype = new Error();
+DocumentNotFound.prototype = Object.create(Error.prototype);
+DocumentNotFound.prototype.constructor = DocumentNotFound;
 DocumentNotFound.prototype.name = "Document not found";
 module.exports.DocumentNotFound = DocumentNotFound;
 
@@ -21,7 +22,8 @@ function InvalidWrite(message, raw) {
   this.message = message;
   this.raw = raw;
 };
-InvalidWrite.prototype = new Error();
+DocumentNotFound.prototype = Object.create(Error.prototype);
+DocumentNotFound.prototype.constructor = InvalidWrite;
 InvalidWrite.prototype.name = "Invalid write";
 module.exports.InvalidWrite = InvalidWrite;
 
@@ -34,6 +36,7 @@ function ValidationError(message) {
     Error.captureStackTrace(this, ValidationError);
     this.message = message;
 };
-ValidationError.prototype = new Error();
+DocumentNotFound.prototype = Object.create(Error.prototype);
+DocumentNotFound.prototype.constructor = ValidationError;
 ValidationError.prototype.name = "Document failed validation";
 module.exports.ValidationError = ValidationError;

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -22,8 +22,8 @@ function InvalidWrite(message, raw) {
   this.message = message;
   this.raw = raw;
 };
-DocumentNotFound.prototype = Object.create(Error.prototype);
-DocumentNotFound.prototype.constructor = InvalidWrite;
+InvalidWrite.prototype = Object.create(Error.prototype);
+InvalidWrite.prototype.constructor = InvalidWrite;
 InvalidWrite.prototype.name = "Invalid write";
 module.exports.InvalidWrite = InvalidWrite;
 
@@ -36,7 +36,7 @@ function ValidationError(message) {
     Error.captureStackTrace(this, ValidationError);
     this.message = message;
 };
-DocumentNotFound.prototype = Object.create(Error.prototype);
-DocumentNotFound.prototype.constructor = ValidationError;
+ValidationError.prototype = Object.create(Error.prototype);
+ValidationError.prototype.constructor = ValidationError;
 ValidationError.prototype.name = "Document failed validation";
 module.exports.ValidationError = ValidationError;


### PR DESCRIPTION
You forgot to overwrite the default prototype.constructor property with the new Error classes created.
I also replace the prototype from
```javascript
new Error
```
with
```javascript
Object.create(Error.prototype)
```
Which is a cleaner way to do an inheritance (not affecting 'this' properties from Error to proto chain ).