### PR TITLE
refactor(errors): provide a proper error hierarchy

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,80 +1,84 @@
-var DOCUMENT_NOT_FOUND_REGEX = new RegExp('^The query did not find a document and returned null.*');
-module.exports.DOCUMENT_NOT_FOUND_REGEX = DOCUMENT_NOT_FOUND_REGEX;
-
-var DUPLICATE_PRIMARY_KEY_REGEX = new RegExp('^Duplicate primary key.*');
-module.exports.DUPLICATE_PRIMARY_KEY_REGEX = DUPLICATE_PRIMARY_KEY_REGEX;
-
+"use strict";
+var util = require('util'),
+    errors = module.exports = {};
 
 /**
- * DocumentNotFound error which is returned when `get` returns `null`.
- * "Extends" Error
+ * The base error that all thinky related errors derive from
+ *
+ * @constructor
+ * @alias Error
  */
-function DocumentNotFound(message) {
-  Error.captureStackTrace(this, DocumentNotFound);
-  this.message = message || "The query did not find a document and returned null.";
+errors.ThinkyError = function() {
+  var tmp = Error.apply(this, arguments);
+  tmp.name = this.name = 'ThinkyError';
+
+  this.message = tmp.message;
+  if (Error.captureStackTrace)
+    Error.captureStackTrace(this, this.constructor);
 };
-DocumentNotFound.prototype = Object.create(Error.prototype);
-DocumentNotFound.prototype.constructor = DocumentNotFound;
-DocumentNotFound.prototype.name = "Document not found";
-module.exports.DocumentNotFound = DocumentNotFound;
-
+util.inherits(errors.ThinkyError, Error);
 
 /**
- * InvalidWrite error which is returned when an inplace update/replace return
- * anon valid document.
- * "Extends" Error
+ * Thrown or returned when `get` returns `null`.
+ * @extends ThinkyError
  */
-function InvalidWrite(message, raw) {
-  Error.captureStackTrace(this, InvalidWrite);
-  this.message = message;
+errors.DocumentNotFound = function(message) {
+  message = message || "The query did not find a document and returned null.";
+  errors.ThinkyError.call(this, message);
+  this.name = 'DocumentNotFoundError';
+};
+util.inherits(errors.DocumentNotFound, errors.ThinkyError);
+
+/**
+ * Thrown or returned when an in place update/replace returns an invalid document.
+ * @extends ThinkyError
+ */
+errors.InvalidWrite = function(message, raw) {
+  errors.ThinkyError.call(this, message);
+  this.name = 'InvalidWriteError';
   this.raw = raw;
 };
-InvalidWrite.prototype = Object.create(Error.prototype);
-InvalidWrite.prototype.constructor = InvalidWrite;
-InvalidWrite.prototype.name = "Invalid write";
-module.exports.InvalidWrite = InvalidWrite;
-
+util.inherits(errors.InvalidWrite, errors.ThinkyError);
 
 /**
- * ValidationError error which is returned when validation of a document fails.
- * "Extends" Error
+ * Thrown or returned when validation of a document fails.
+ * @extends ThinkyError
  */
-function ValidationError(message) {
-    Error.captureStackTrace(this, ValidationError);
-    this.message = message;
+errors.ValidationError = function(message) {
+  errors.ThinkyError.call(this, message);
+  this.name = 'ValidationError';
 };
-ValidationError.prototype = Object.create(Error.prototype);
-ValidationError.prototype.constructor = ValidationError;
-ValidationError.prototype.name = "Document failed validation";
-module.exports.ValidationError = ValidationError;
-
+util.inherits(errors.ValidationError, errors.ThinkyError);
 
 /**
- * DuplicatePrimaryKey error which is returned when the primary key unique constraint of a document fails.
- * "Extends" Error
+ * Thrown or returned when the primary key unique document constraint fails.
+ * @extends ThinkyError
  */
-function DuplicatePrimaryKey(message) {
-    Error.captureStackTrace(this, DuplicatePrimaryKey);
-    this.message = message;
+errors.DuplicatePrimaryKey = function(message) {
+  errors.ThinkyError.call(this, message);
+  this.name = 'DuplicatePrimaryKeyError';
 };
-DuplicatePrimaryKey.prototype = new Error();
-DuplicatePrimaryKey.prototype.name = "Duplicate primary key";
-module.exports.DuplicatePrimaryKey = DuplicatePrimaryKey;
+util.inherits(errors.DuplicatePrimaryKey, errors.ThinkyError);
 
+/**
+ * regular expressions used to determine which errors should be thrown
+ */
+errors.DOCUMENT_NOT_FOUND_REGEX = new RegExp('^The query did not find a document and returned null.*');
+errors.DUPLICATE_PRIMARY_KEY_REGEX = new RegExp('^Duplicate primary key.*');
 
-module.exports.create = function (errorOrMessage) {
+/**
+ * Creates an appropriate error given either an instance of Error or a message
+ * from the RethinkDB driver
+ */
+errors.create = function(errorOrMessage) {
   var message = (errorOrMessage instanceof Error) ? errorOrMessage.message : errorOrMessage;
-
-  if(message.match(DOCUMENT_NOT_FOUND_REGEX)) {
-    return new DocumentNotFound(message);
-  }
-
-  if(message.match(DUPLICATE_PRIMARY_KEY_REGEX)) {
-    return new DuplicatePrimaryKey(message);
-  }
-
-  if (errorOrMessage instanceof Error) {
+  if (message.match(errors.DOCUMENT_NOT_FOUND_REGEX)) {
+    return new errors.DocumentNotFound(message);
+  } else if (message.match(errors.DUPLICATE_PRIMARY_KEY_REGEX)) {
+    return new errors.DuplicatePrimaryKey(message);
+  } else if (errorOrMessage instanceof Error) {
     return errorOrMessage;
   }
-  return new Error(errorOrMessage);
+
+  return new errors.ThinkyError(errorOrMessage);
 };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -54,9 +54,10 @@ util.inherits(errors.ValidationError, errors.ThinkyError);
  * Thrown or returned when the primary key unique document constraint fails.
  * @extends ThinkyError
  */
-errors.DuplicatePrimaryKey = function(message) {
+errors.DuplicatePrimaryKey = function(message, primaryKey) {
   errors.ThinkyError.call(this, message);
   this.name = 'DuplicatePrimaryKeyError';
+  if (!!primaryKey) this.primaryKey = primaryKey;
 };
 util.inherits(errors.DuplicatePrimaryKey, errors.ThinkyError);
 
@@ -64,7 +65,7 @@ util.inherits(errors.DuplicatePrimaryKey, errors.ThinkyError);
  * regular expressions used to determine which errors should be thrown
  */
 errors.DOCUMENT_NOT_FOUND_REGEX = new RegExp('^The query did not find a document and returned null.*');
-errors.DUPLICATE_PRIMARY_KEY_REGEX = new RegExp('^Duplicate primary key.*');
+errors.DUPLICATE_PRIMARY_KEY_REGEX = new RegExp('^Duplicate primary key `(.*)`.*');
 
 /**
  * Creates an appropriate error given either an instance of Error or a message
@@ -75,7 +76,8 @@ errors.create = function(errorOrMessage) {
   if (message.match(errors.DOCUMENT_NOT_FOUND_REGEX)) {
     return new errors.DocumentNotFound(message);
   } else if (message.match(errors.DUPLICATE_PRIMARY_KEY_REGEX)) {
-    return new errors.DuplicatePrimaryKey(message);
+    var primaryKey = message.match(errors.DUPLICATE_PRIMARY_KEY_REGEX)[1];
+    return new errors.DuplicatePrimaryKey(message, primaryKey);
   } else if (errorOrMessage instanceof Error) {
     return errorOrMessage;
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/neumino/thinky/issues"
   },
   "dependencies":{
-    "rethinkdbdash": "~2.2.0",
+    "rethinkdbdash": "^2.2.15",
     "bluebird": "~2.1.3",
     "validator": "~ 3.22.1"
   },

--- a/test/document.js
+++ b/test/document.js
@@ -107,6 +107,7 @@ describe('save', function() {
         }).error(function (err) {
           assert(err instanceof Errors.DuplicatePrimaryKey);
           assert(err.message.match(Errors.DUPLICATE_PRIMARY_KEY_REGEX));
+          assert.equal(err.primaryKey, 'id');
           done();
         });
       }).error(done);


### PR DESCRIPTION
This is the first change based on the discussion in #417, bringing the errors in thinky into a strict hierarchy based on a common `ThinkyError` base.

This also includes the change to provide the `primaryKey` in the `DocumentNotFound` error, as well as bump to use semver for `rethinkdbdash` to alleviate wercker errors.