### PR TITLE
#421 Implement backref option to hasAndBelongsToMany with same table, same key 

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1111,7 +1111,16 @@ Document.prototype._saveLinks = function(docToSave, saveAll, resolve, reject) {
                     }
                   }
                   else {
-                    self.__proto__._links[joins[key].link][newLink[joins[key].model.getTableName()+"_"+joins[key].rightKey]] = true;
+                    if ((constructor.getTableName() === joins[key].model.getTableName())
+                        && (joins[key].leftKey === joins[key].rightKey)) {
+                      if (joins[key].reverse) {
+                        self.__proto__._links[joins[key].link][newLink[joins[key][joins[key].leftKey+"_"+joins[key].leftKey][1]] = true;
+                      } else {
+                        self.__proto__._links[joins[key].link][newLink[joins[key][joins[key].leftKey+"_"+joins[key].leftKey][0]] = true;
+                      }
+                    } else {
+                      self.__proto__._links[joins[key].link][newLink[joins[key].model.getTableName()+"_"+joins[key].rightKey]] = true;
+                    }
                   }
                   resolve();
                 }).error(reject);

--- a/lib/document.js
+++ b/lib/document.js
@@ -1050,7 +1050,7 @@ Document.prototype._saveLinks = function(docToSave, saveAll, resolve, reject) {
         var oldKeys = self.__proto__._links[joins[key].link];
 
         util.loopKeys(newKeys, function(newKeys, link) {
-          if (oldKeys[rightValue] !== true) {
+          if (oldKeys[link] !== true) {
             var newLink = {};
             var leftValue = self[joins[key].leftKey];
             var rightValue = link;

--- a/lib/document.js
+++ b/lib/document.js
@@ -1050,39 +1050,46 @@ Document.prototype._saveLinks = function(docToSave, saveAll, resolve, reject) {
         var oldKeys = self.__proto__._links[joins[key].link];
 
         util.loopKeys(newKeys, function(newKeys, link) {
-          if (oldKeys[link] !== true) {
+          if (oldKeys[rightValue] !== true) {
             var newLink = {};
+            var leftValue = self[joins[key].leftKey];
+            var rightValue = link;
+
+            if (joins[key].reverse) {
+              leftValue = link;
+              rightValue = self[joins[key].leftKey];
+            }
 
             if ((constructor.getTableName() === joins[key].model.getTableName())
               && (joins[key].leftKey === joins[key].rightKey)) {
 
-              // We link on the same model and same key
+              // We rightValue on the same model and same key
               // We don't want to save redundant field
-              if (link < self[joins[key].leftKey]) {
-                newLink.id = link+"_"+self[joins[key].leftKey];
+              if (rightValue < leftValue) {
+                newLink.id = rightValue+"_"+leftValue;
               }
               else {
-                newLink.id = self[joins[key].leftKey]+"_"+link;
+                newLink.id = leftValue+"_"+rightValue;
               }
-              newLink[joins[key].leftKey+"_"+joins[key].leftKey] = [link, self[joins[key].leftKey]];
+              newLink[joins[key].leftKey+"_"+joins[key].leftKey] = [rightValue, leftValue];
             }
             else {
-              newLink[constructor.getTableName()+"_"+joins[key].leftKey] = self[joins[key].leftKey];
-              newLink[joins[key].model.getTableName()+"_"+joins[key].rightKey] = link;
+              newLink[constructor.getTableName()+"_"+joins[key].leftKey] = leftValue;
+              newLink[joins[key].model.getTableName()+"_"+joins[key].rightKey] = rightValue;
 
               // Create the primary key
               if (constructor.getTableName() < joins[key].model.getTableName()) {
-                newLink.id = self[joins[key].leftKey]+"_"+link;
+                newLink.id = leftValue+"_"+rightValue;
               }
               else if (constructor.getTableName() > joins[key].model.getTableName()) {
-                newLink.id = link+"_"+self[joins[key].leftKey];
+                newLink.id = rightValue+"_"+leftValue;
               }
               else {
-                if (link < self[joins[key].leftKey]) {
-                  newLink.id = link+"_"+self[joins[key].leftKey];
+                if (rightValue < leftValue) {
+                  newLink.id = rightValue+"_"+leftValue;
                 }
                 else {
-                  newLink.id = self[joins[key].leftKey]+"_"+link;
+                  newLink.id = leftValue+"_"+rightValue;
                 }
               }
             }

--- a/lib/document.js
+++ b/lib/document.js
@@ -1055,13 +1055,14 @@ Document.prototype._saveLinks = function(docToSave, saveAll, resolve, reject) {
             var leftValue = self[joins[key].leftKey];
             var rightValue = link;
 
-            if (joins[key].reverse) {
-              leftValue = link;
-              rightValue = self[joins[key].leftKey];
-            }
 
             if ((constructor.getTableName() === joins[key].model.getTableName())
               && (joins[key].leftKey === joins[key].rightKey)) {
+
+              if (joins[key].reverse) {
+                leftValue = link;
+                rightValue = self[joins[key].leftKey];
+              }
 
               // We rightValue on the same model and same key
               // We don't want to save redundant field
@@ -1098,7 +1099,16 @@ Document.prototype._saveLinks = function(docToSave, saveAll, resolve, reject) {
               promisesLink.push(new Promise(function(resolve, reject) {
                 r.table(self._getModel()._joins[key].link).insert(newLink, {conflict: "replace", returnChanges: 'always'}).run().then(function(result) {
                   if (Array.isArray(result.changes) && result.changes.length > 0) {
-                    self.__proto__._links[joins[key].link][result.changes[0].new_val[joins[key].model.getTableName()+"_"+joins[key].rightKey]] = true;
+                    if ((constructor.getTableName() === joins[key].model.getTableName())
+                        && (joins[key].leftKey === joins[key].rightKey)) {
+                      if (joins[key].reverse) {
+                        self.__proto__._links[joins[key].link][result.changes[0].new_val[joins[key].leftKey+"_"+joins[key].leftKey][1]] = true;
+                      } else {
+                        self.__proto__._links[joins[key].link][result.changes[0].new_val[joins[key].leftKey+"_"+joins[key].leftKey][0]] = true;
+                      }
+                    } else {
+                      self.__proto__._links[joins[key].link][result.changes[0].new_val[joins[key].model.getTableName()+"_"+joins[key].rightKey]] = true;
+                    }
                   }
                   else {
                     self.__proto__._links[joins[key].link][newLink[joins[key].model.getTableName()+"_"+joins[key].rightKey]] = true;
@@ -1113,11 +1123,20 @@ Document.prototype._saveLinks = function(docToSave, saveAll, resolve, reject) {
         var keysToDelete = []
         util.loopKeys(oldKeys, function(oldKeys, link) {
           if (newKeys[link] === undefined) {
-            if (constructor.getTableName() < joins[key].model.getTableName()) {
-              keysToDelete.push(self[joins[key].leftKey]+"_"+link);
-            }
-            else {
-              keysToDelete.push(link+"_"+self[joins[key].leftKey]);
+            if ((constructor.getTableName() === joins[key].model.getTableName())
+                && (joins[key].leftKey === joins[key].rightKey)) {
+              if (link < self[joins[key].leftKey]) {
+                keysToDelete.push(link+"_"+self[joins[key].leftKey]);
+              } else {
+                keysToDelete.push(self[joins[key].leftKey]+"_"+link);
+              }
+            } else {
+              if (constructor.getTableName() < joins[key].model.getTableName()) {
+                keysToDelete.push(self[joins[key].leftKey]+"_"+link);
+              }
+              else {
+                keysToDelete.push(link+"_"+self[joins[key].leftKey]);
+              }
             }
           }
         });

--- a/lib/document.js
+++ b/lib/document.js
@@ -1114,9 +1114,9 @@ Document.prototype._saveLinks = function(docToSave, saveAll, resolve, reject) {
                     if ((constructor.getTableName() === joins[key].model.getTableName())
                         && (joins[key].leftKey === joins[key].rightKey)) {
                       if (joins[key].reverse) {
-                        self.__proto__._links[joins[key].link][newLink[joins[key][joins[key].leftKey+"_"+joins[key].leftKey][1]] = true;
+                        self.__proto__._links[joins[key].link][newLink[joins[key].leftKey+"_"+joins[key].leftKey][1]] = true;
                       } else {
-                        self.__proto__._links[joins[key].link][newLink[joins[key][joins[key].leftKey+"_"+joins[key].leftKey][0]] = true;
+                        self.__proto__._links[joins[key].link][newLink[joins[key].leftKey+"_"+joins[key].leftKey][0]] = true;
                       }
                     } else {
                       self.__proto__._links[joins[key].link][newLink[joins[key].model.getTableName()+"_"+joins[key].rightKey]] = true;

--- a/lib/document.js
+++ b/lib/document.js
@@ -1122,20 +1122,22 @@ Document.prototype._saveLinks = function(docToSave, saveAll, resolve, reject) {
 
         var keysToDelete = []
         util.loopKeys(oldKeys, function(oldKeys, link) {
-          if (newKeys[link] === undefined) {
-            if ((constructor.getTableName() === joins[key].model.getTableName())
-                && (joins[key].leftKey === joins[key].rightKey)) {
-              if (link < self[joins[key].leftKey]) {
-                keysToDelete.push(link+"_"+self[joins[key].leftKey]);
+          if (oldKeys[link] === true) {
+            if (newKeys[link] === undefined) {
+              if ((constructor.getTableName() === joins[key].model.getTableName())
+                  && (joins[key].leftKey === joins[key].rightKey)) {
+                if (link < self[joins[key].leftKey]) {
+                  keysToDelete.push(link+"_"+self[joins[key].leftKey]);
+                } else {
+                  keysToDelete.push(self[joins[key].leftKey]+"_"+link);
+                }
               } else {
-                keysToDelete.push(self[joins[key].leftKey]+"_"+link);
-              }
-            } else {
-              if (constructor.getTableName() < joins[key].model.getTableName()) {
-                keysToDelete.push(self[joins[key].leftKey]+"_"+link);
-              }
-              else {
-                keysToDelete.push(link+"_"+self[joins[key].leftKey]);
+                if (constructor.getTableName() < joins[key].model.getTableName()) {
+                  keysToDelete.push(self[joins[key].leftKey]+"_"+link);
+                }
+                else {
+                  keysToDelete.push(link+"_"+self[joins[key].leftKey]);
+                }
               }
             }
           }

--- a/lib/model.js
+++ b/lib/model.js
@@ -567,7 +567,18 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
     rightKey: rightKey,
     type: 'hasAndBelongsToMany',
     link: link,
-    linkModel: linkModel
+    linkModel: linkModel,
+    backref: options.backref,
+    reverse: false
+  }
+
+  // The relation is built for back-side reference.
+  // The relation is built for the same model, using the same key
+  if (options.backref && (this.getTableName() === joinedModel.getTableName()) && (leftKey === rightKey)) {
+    this._getModel()._joins[options.backref] = Object.assign({}, {
+      backref: fieldDoc,
+      reverse: true
+    }, this._getModel()._joins[fieldDoc])
   }
 
   joinedModel._getModel()._reverseJoins[self.getTableName()] = {

--- a/lib/model.js
+++ b/lib/model.js
@@ -573,14 +573,11 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
   // The relation is built for back-side reference.
   // The relation is built for the same model, using the same key
   if (options.backref && (this.getTableName() === joinedModel.getTableName()) && (leftKey === rightKey)) {
-    Object.assign(join, {
-      backref: options.backref,
-      reverse: false
-    });
-    reverseJoin = Object.assign({}, join, {
-      backref: fieldDoc,
-      reverse: true
-    });
+    reverseJoin = util.deepCopy(join);
+    join.backref = options.backref;
+    join.reverse = false;
+    reverseJoin.backref = fieldDoc;
+    reverseJoin.reverse = true;
     this._getModel()._joins[options.backref] = reverseJoin;
   }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -525,7 +525,7 @@ Model.prototype.hasMany = function(joinedModel, fieldDoc, leftKey, rightKey, opt
  */
 Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, rightKey, options) {
   var self = this;
-  var link, query;
+  var link, query, join, reverseJoin;
   var thinky = this._getModel()._thinky;
   options = options || {};
 
@@ -560,25 +560,28 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
     linkModel = thinky.models[link];
   }
 
-
-  this._getModel()._joins[fieldDoc] = {
+  join = {
     model: joinedModel,
     leftKey: leftKey,
     rightKey: rightKey,
     type: 'hasAndBelongsToMany',
     link: link,
-    linkModel: linkModel,
-    backref: options.backref,
-    reverse: false
-  }
+    linkModel: linkModel
+  };
+  this._getModel()._joins[fieldDoc] = join;
 
   // The relation is built for back-side reference.
   // The relation is built for the same model, using the same key
   if (options.backref && (this.getTableName() === joinedModel.getTableName()) && (leftKey === rightKey)) {
-    this._getModel()._joins[options.backref] = Object.assign({}, {
+    Object.assign(join, {
+      backref: options.backref,
+      reverse: false
+    });
+    reverseJoin = Object.assign({}, join, {
       backref: fieldDoc,
       reverse: true
-    }, this._getModel()._joins[fieldDoc])
+    });
+    this._getModel()._joins[options.backref] = reverseJoin;
   }
 
   joinedModel._getModel()._reverseJoins[self.getTableName()] = {

--- a/lib/model.js
+++ b/lib/model.js
@@ -525,7 +525,7 @@ Model.prototype.hasMany = function(joinedModel, fieldDoc, leftKey, rightKey, opt
  */
 Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, rightKey, options) {
   var self = this;
-  var link, query, join, reverseJoin;
+  var link, query, join, backrefJoin;
   var thinky = this._getModel()._thinky;
   options = options || {};
 
@@ -569,24 +569,18 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
     linkModel: linkModel
   };
   this._getModel()._joins[fieldDoc] = join;
+  joinedModel._getModel()._reverseJoins[self.getTableName()] = join
 
   // The relation is built for back-side reference.
   // The relation is built for the same model, using the same key
   if (options.backref && (this.getTableName() === joinedModel.getTableName()) && (leftKey === rightKey)) {
-    reverseJoin = util.deepCopy(join);
+    backrefJoin = util.deepCopy(join);
+
     join.backref = options.backref;
     join.reverse = false;
-    reverseJoin.backref = fieldDoc;
-    reverseJoin.reverse = true;
-    this._getModel()._joins[options.backref] = reverseJoin;
-  }
-
-  joinedModel._getModel()._reverseJoins[self.getTableName()] = {
-    leftKey: leftKey,
-    rightKey: rightKey,
-    type: 'hasAndBelongsToMany',
-    link: link,
-    linkModel: linkModel
+    backrefJoin.backref = fieldDoc;
+    backrefJoin.reverse = true;
+    this._getModel()._joins[options.backref] = backrefJoin;
   }
 
   if (options.init !== false) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -393,6 +393,22 @@ Query.prototype.getJoin = function(modelToGet, getAll, gotModel) {
               // In case the model is linked with itself on the same key
 
               innerQuery = r.table(joins[key].link).getAll(doc(joins[key].leftKey), {index: joins[key].leftKey+"_"+joins[key].leftKey}).concatMap(function(link) {
+                if (joins[key].backref) {
+                  return joins[key].reverse ?
+                    r.branch(
+                      doc(joins[key].leftKey).eq(link(joins[key].leftKey+"_"+joins[key].leftKey).nth(1)),
+                      r.table(joins[key].model.getTableName()).getAll(
+                        link(joins[key].leftKey+"_"+joins[key].leftKey).nth(0),
+                        {index: joins[key].rightKey}
+                      ), []
+                    ) : r.branch(
+                      doc(joins[key].leftKey).eq(link(joins[key].leftKey+"_"+joins[key].leftKey).nth(0)),
+                      r.table(joins[key].model.getTableName()).getAll(
+                        link(joins[key].leftKey+"_"+joins[key].leftKey).nth(1),
+                        {index: joins[key].rightKey}
+                      ), []
+                    );
+                }
                 return r.table(joins[key].model.getTableName()).getAll(
                   r.branch(
                     doc(joins[key].leftKey).eq(link(joins[key].leftKey+"_"+joins[key].leftKey).nth(0)),
@@ -542,14 +558,14 @@ Query.prototype.addRelation = function(field, joinedDocument) {
               return r.object(
                 'id', leftKey.add('_').add(rightKey),
                 model.getTableName()+"_"+joins[field].leftKey, leftKey,
-                joinedModel.getTableName()+"_"+joins[field].rightKey,rightKey 
+                joinedModel.getTableName()+"_"+joins[field].rightKey,rightKey
               )
             }
             else if (model.getTableName() > joinedModel.getTableName()) {
               return r.object(
                 'id', rightKey.add('_').add(leftKey),
                 model.getTableName()+"_"+joins[field].leftKey, leftKey,
-                joinedModel.getTableName()+"_"+joins[field].rightKey,rightKey 
+                joinedModel.getTableName()+"_"+joins[field].rightKey,rightKey
               )
             }
             else {
@@ -558,12 +574,12 @@ Query.prototype.addRelation = function(field, joinedDocument) {
                 r.object(
                   'id', leftKey.add('_').add(rightKey),
                   model.getTableName()+"_"+joins[field].leftKey, leftKey,
-                  joinedModel.getTableName()+"_"+joins[field].rightKey,rightKey 
+                  joinedModel.getTableName()+"_"+joins[field].rightKey,rightKey
                 ),
                 r.object(
                   'id', rightKey.add('_').add(leftKey),
                   model.getTableName()+"_"+joins[field].leftKey, leftKey,
-                  joinedModel.getTableName()+"_"+joins[field].rightKey,rightKey 
+                  joinedModel.getTableName()+"_"+joins[field].rightKey,rightKey
                 )
               )
             }

--- a/lib/query.js
+++ b/lib/query.js
@@ -538,20 +538,21 @@ Query.prototype.addRelation = function(field, joinedDocument) {
           return link.do(function(rightKey) {
             var tmp;
             if (joins[field].reverse) {
-              leftKey = tmp;
+              tmp = leftKey;
               leftKey = rightKey;
-              rightKey = leftKey;
+              rightKey = tmp;
             }
+
             return r.branch(
-                rightKey.lt(leftKey),
-                r.object(
-                  'id', rightKey.add('_').add(leftKey),
-                  joins[field].leftKey+"_"+joins[field].leftKey, [leftKey, rightKey]
-                ),
-                r.object(
-                  'id', leftKey.add('_').add(rightKey),
-                  joins[field].leftKey+"_"+joins[field].leftKey, [leftKey, rightKey]
-                )
+              rightKey.lt(leftKey),
+              r.object(
+                'id', rightKey.add('_').add(leftKey),
+                joins[field].leftKey+"_"+joins[field].leftKey, [rightKey, leftKey]
+              ),
+              r.object(
+                'id', leftKey.add('_').add(rightKey),
+                joins[field].leftKey+"_"+joins[field].leftKey, [rightKey, leftKey]
+              )
             )
           });
         });

--- a/lib/query.js
+++ b/lib/query.js
@@ -400,21 +400,21 @@ Query.prototype.getJoin = function(modelToGet, getAll, gotModel) {
                     leftValue = link(joins[key].leftKey+"_"+joins[key].leftKey).nth(0);
                     rightValue = link(joins[key].leftKey+"_"+joins[key].leftKey).nth(1);
                   }
-
                   return r.branch(
                     doc(joins[key].leftKey).eq(leftValue),
                     r.table(joins[key].model.getTableName()).getAll(rightValue, {index: joins[key].rightKey}),
                     []
                   );
                 }
-
-                return r.table(joins[key].model.getTableName()).getAll(
-                  r.branch(
-                    doc(joins[key].leftKey).eq(leftValue),
-                    rightValue,
-                    leftValue
-                  ), {index: joins[key].rightKey}
-                );
+                else {
+                  return r.table(joins[key].model.getTableName()).getAll(
+                    r.branch(
+                      doc(joins[key].leftKey).eq(leftValue),
+                      rightValue,
+                      leftValue
+                    ), {index: joins[key].rightKey}
+                  );
+                }
               });
 
               if ((modelToGet[key] != null) && (typeof modelToGet[key]._apply === 'function')) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -393,29 +393,28 @@ Query.prototype.getJoin = function(modelToGet, getAll, gotModel) {
               // In case the model is linked with itself on the same key
 
               innerQuery = r.table(joins[key].link).getAll(doc(joins[key].leftKey), {index: joins[key].leftKey+"_"+joins[key].leftKey}).concatMap(function(link) {
+                var leftValue = link(joins[key].leftKey+"_"+joins[key].leftKey).nth(1);
+                var rightValue = link(joins[key].leftKey+"_"+joins[key].leftKey).nth(0);
                 if (joins[key].backref) {
-                  return joins[key].reverse ?
-                    r.branch(
-                      doc(joins[key].leftKey).eq(link(joins[key].leftKey+"_"+joins[key].leftKey).nth(1)),
-                      r.table(joins[key].model.getTableName()).getAll(
-                        link(joins[key].leftKey+"_"+joins[key].leftKey).nth(0),
-                        {index: joins[key].rightKey}
-                      ), []
-                    ) : r.branch(
-                      doc(joins[key].leftKey).eq(link(joins[key].leftKey+"_"+joins[key].leftKey).nth(0)),
-                      r.table(joins[key].model.getTableName()).getAll(
-                        link(joins[key].leftKey+"_"+joins[key].leftKey).nth(1),
-                        {index: joins[key].rightKey}
-                      ), []
-                    );
+                  if (joins[key].reverse) {
+                    leftValue = link(joins[key].leftKey+"_"+joins[key].leftKey).nth(0);
+                    rightValue = link(joins[key].leftKey+"_"+joins[key].leftKey).nth(1);
+                  }
+
+                  return r.branch(
+                    doc(joins[key].leftKey).eq(leftValue),
+                    r.table(joins[key].model.getTableName()).getAll(rightValue, {index: joins[key].rightKey}),
+                    []
+                  );
                 }
+
                 return r.table(joins[key].model.getTableName()).getAll(
                   r.branch(
-                    doc(joins[key].leftKey).eq(link(joins[key].leftKey+"_"+joins[key].leftKey).nth(0)),
-                    link(joins[key].leftKey+"_"+joins[key].leftKey).nth(1),
-                    link(joins[key].leftKey+"_"+joins[key].leftKey).nth(0)
-                  )
-                , {index: joins[key].rightKey})
+                    doc(joins[key].leftKey).eq(leftValue),
+                    rightValue,
+                    leftValue
+                  ), {index: joins[key].rightKey}
+                );
               });
 
               if ((modelToGet[key] != null) && (typeof modelToGet[key]._apply === 'function')) {
@@ -537,6 +536,12 @@ Query.prototype.addRelation = function(field, joinedDocument) {
           && (joins[field].leftKey === joins[field].rightKey)) {
         linkValue = self._query(joins[field].leftKey).do(function(leftKey) {
           return link.do(function(rightKey) {
+            var tmp;
+            if (joins[field].reverse) {
+              leftKey = tmp;
+              leftKey = rightKey;
+              rightKey = leftKey;
+            }
             return r.branch(
                 rightKey.lt(leftKey),
                 r.object(

--- a/lib/query.js
+++ b/lib/query.js
@@ -653,7 +653,17 @@ Query.prototype.removeRelation = function(field, joinedDocument) {
           // range are not supported at the moment, so keys is an object and we don't have to worry about empty sequences
           if ((model.getTableName() === joinedModel.getTableName())
               && (joins[field].leftKey === joins[field].rightKey)) {
-            return linkModel.getAll(leftKey, {index: joins[field].leftKey+'_'+joins[field].leftKey}).delete()._query
+            return linkModel.getAll(leftKey, {index: joins[field].leftKey+'_'+joins[field].leftKey}).filter(function(link) {
+              if (joins[field].backref) {
+                if (joins[field].reverse) {
+                  return link(joins[field].leftKey+'_'+joins[field].leftKey).nth(0).eq(leftKey);
+                } else {
+                  return link(joins[field].leftKey+'_'+joins[field].leftKey).nth(1).eq(leftKey);
+                }
+              } else {
+                return true;
+              }
+            }).delete()._query
           }
           else {
             return linkModel.getAll(leftKey, {index: model.getTableName()+'_'+joins[field].leftKey}).delete()._query

--- a/lib/query.js
+++ b/lib/query.js
@@ -536,11 +536,8 @@ Query.prototype.addRelation = function(field, joinedDocument) {
           && (joins[field].leftKey === joins[field].rightKey)) {
         linkValue = self._query(joins[field].leftKey).do(function(leftKey) {
           return link.do(function(rightKey) {
-            var tmp;
             if (joins[field].reverse) {
-              tmp = leftKey;
-              leftKey = rightKey;
-              rightKey = tmp;
+              leftKey = [rightKey, rightKey = leftKey][0];  // swap keys
             }
 
             return r.branch(

--- a/test/model.js
+++ b/test/model.js
@@ -546,6 +546,20 @@ describe("Joins", function() {
       }).error(done);
     });
   });
+
+  it('hasAndBelongsToMany with same model, same key, backref option should save reverse join', function() {
+    var model = thinky.createModel(modelNames[0], { id: String });
+    model.hasAndBelongsToMany(model, 'following', 'id', 'id', { backref: 'followers' });
+
+    assert(model._joins['following']);
+    assert.equal(model._joins['following'].backref, 'followers');
+    assert.equal(model._joins['following'].reverse, false);
+
+    assert(model._joins['followers']);
+    assert.equal(model._joins['followers'].backref, 'following');
+    assert.equal(model._joins['followers'].reverse, true);
+  });
+
   it('_apply is reserved ', function() {
     var model = thinky.createModel(modelNames[0], { id: String, notid1: String }, {init: false});
 


### PR DESCRIPTION
Implementation for #421 issue.

1. Implement `backref` option to `hasAndBelongsToMany` with same table, same key.
2. Fix some bugs on `hasAndBelongsToMany` with same table, same key.
3. Create test cases.