### PR TITLE
update bluebird version in order to prevent starvation by nextTick

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies":{
     "rethinkdbdash": "^2.2.15",
-    "bluebird": "~2.1.3",
+    "bluebird": "~2.10.2",
     "validator": "~ 3.22.1"
   },
   "devDependencies": {


### PR DESCRIPTION
In nodejs 4.* it is not recommend to use .nextTick() because it can cause to starvation, 
and the recommend function is setImmediate() 

the older bluebird version used nextTick()

https://github.com/nodejs/node/wiki/API-changes-between-v0.10-and-v4
