### PR TITLE
Accept table options when creating a model

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -43,6 +43,9 @@ function Model(name, schema, options, thinky) {
 
   this._pk = (options.pk != null) ? options.pk : 'id';
 
+  this._table = (options.table != null) ? options.table : {};
+  this._table.primaryKey = this._pk;
+
   this._thinky = thinky;
 
   this._validator = options.validator;
@@ -202,7 +205,7 @@ Model.prototype.tableReady = function() {
   var r = model._thinky.r;
   this._tableReadyPromise = model._thinky.dbReady()
   .then(function() {
-    return r.tableCreate(model._name, {primaryKey: model._pk}).run();
+    return r.tableCreate(model._name, model._table).run();
   })
   .error(function(error) {
     if (error.message.match(/Table `.*` already exists/)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinky",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "RethinkDB ORM for Node.js",
   "main": "lib/thinky.js",
   "directories": {
@@ -26,7 +26,7 @@
   "dependencies":{
     "rethinkdbdash": "~2.3.0",
     "bluebird": "~2.10.2",
-    "validator": "~ 3.22.1"
+    "validator": "~3.22.1"
   },
   "devDependencies": {
     "mocha": "~1.21.5"

--- a/test/settings.js
+++ b/test/settings.js
@@ -74,6 +74,20 @@ describe('Options', function(){
       });
     });
   });
+  it('table option on a model', function(done){
+    var name = util.s8();
+    var Model = thinky.createModel(name, {id: String, name: String}, {
+      table: {
+        durability: 'soft'
+      }
+    });
+    Model.once('ready', function() {
+      r.table(Model.getTableName()).config().run().then(function(result) {
+        assert.equal(result.durability, 'soft');
+        done();
+      });
+    });
+  });
   it('Options on a document', function(){
     var name = util.s8();
     var Model = thinky.createModel(name, {id: String, name: String});


### PR DESCRIPTION
Expose passing options to internal `r.tableCreate` which allows us to do things like set the table durability, replicas, etc.