### PR TITLE
almost unable to read code on mobile

### DIFF
--- a/stylesheets/mobile.css
+++ b/stylesheets/mobile.css
@@ -64,3 +64,6 @@ ul.doc-nav {
 li{
     list-style: none;
 }
+pre code{
+    font-size:1.5rem !important;
+}


### PR DESCRIPTION
Hi there I prefer to read documentation in mobile, but the example code is so tiny, is almost unreadable.  http://i.imgur.com/8EynsXS.png

I tried to clone the repo and fix it for my self, but seems has all the links with absolutes paths so nothing works. Maybe this pull request will allow to make the code readable.
