### PR TITLE
Added name of the relation to relations info

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -398,7 +398,8 @@ Model.prototype.hasOne = function(joinedModel, fieldDoc, leftKey, rightKey, opti
     model: joinedModel,
     leftKey: leftKey,
     rightKey: rightKey,
-    type: 'hasOne'
+    type: 'hasOne',
+    name: fieldDoc
   }
   joinedModel._getModel()._localKeys[rightKey] = true;
 
@@ -441,7 +442,8 @@ Model.prototype.belongsTo = function(joinedModel, fieldDoc, leftKey, rightKey, o
     model: joinedModel,
     leftKey: leftKey,
     rightKey: rightKey,
-    type: 'belongsTo'
+    type: 'belongsTo',
+    name: fieldDoc
   };
   self._getModel()._localKeys[leftKey] = true;
 
@@ -450,6 +452,7 @@ Model.prototype.belongsTo = function(joinedModel, fieldDoc, leftKey, rightKey, o
     leftKey: leftKey,
     rightKey: rightKey,
     type: 'belongsTo',
+    name: fieldDoc
   }
 
   options = options || {};
@@ -500,7 +503,8 @@ Model.prototype.hasMany = function(joinedModel, fieldDoc, leftKey, rightKey, opt
     model: joinedModel,
     leftKey: leftKey,
     rightKey: rightKey,
-    type: 'hasMany'
+    type: 'hasMany',
+    name: fieldDoc
   };
   joinedModel._getModel()._localKeys[rightKey] = true;
 
@@ -571,7 +575,8 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
     rightKey: rightKey,
     type: 'hasAndBelongsToMany',
     link: link,
-    linkModel: linkModel
+    linkModel: linkModel,
+    name: fieldDoc
   }
 
   joinedModel._getModel()._reverseJoins[self.getTableName()] = {
@@ -579,7 +584,8 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
     rightKey: rightKey,
     type: 'hasAndBelongsToMany',
     link: link,
-    linkModel: linkModel
+    linkModel: linkModel,
+    name: self.getTableName()
   }
 
   if (options.init !== false) {


### PR DESCRIPTION
This tiny PR is adding the name of the **relation** to the relations Object info.

Why is needed?

let's say a function accept the relation info in this way:

~~~
doSomethingWithRelation(User._joins['tasks']);

function doSomethingWithRelation(relationInfo) {
   // here i lost the name of the relation for further algorithms
}
~~~

With this PR we can access to the name of the relation

`relationInfo.name`