### PR TITLE
Fixes a promise warning

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -220,6 +220,7 @@ Model.prototype.tableReady = function() {
     if (!self._pendingPromises.length) {
       self.emit('ready');
     }
+    return null;
   });
 };
 


### PR DESCRIPTION
Fixes a promise warning because nothing is being returned.

Actual message: `Warning: a promise was created in a handler but was not returned from it`

Stack Trace
```
Warning: a promise was created in a handler but was not returned from it
  at process._tickDomainCallback (node.js:486:13)
  at process.wrappedFunction (/Users/leland/Sites/ListReports/portal/node_modules/newrelic/lib/transaction/tracer/index.js:250:51)
From previous event:
  at Promise.wrappedFunction [as _then] (/Users/leland/Sites/ListReports/portal/node_modules/newrelic/lib/transaction/tracer/index.js:225:51)
  at Model.tableReady (/Users/leland/Sites/ListReports/portal/node_modules/thinky/lib/model.js:215:34)
  at Function.Model.new (/Users/leland/Sites/ListReports/portal/node_modules/thinky/lib/model.js:167:11)
  at Thinky.createModel (/Users/leland/Sites/ListReports/portal/node_modules/thinky/lib/thinky.js:130:24)
```