### PR TITLE
Add pingInterval option to config

### DIFF
--- a/lib/thinky.js
+++ b/lib/thinky.js
@@ -44,6 +44,10 @@ function Thinky(config) {
   self._options.validate =
     (config.validate != null) ? config.validate : 'onsave';
 
+  // The connection will be pinged every <pingInterval> seconds
+  self._options.pingInterval =
+    (config.pingInterval != null) ? config.pingInterval : -1;
+
   if (config.r === undefined) {
     self.r = rethinkdbdash(config);
   }

--- a/test/settings.js
+++ b/test/settings.js
@@ -26,6 +26,7 @@ var assert = require('assert');
 describe('Options', function(){
   it('Options on the top level namespace', function(){
     assert.deepEqual(thinky.getOptions(), {
+      pingInterval: -1,
       timeFormat: 'raw',
       enforce_extra: 'strict',
       enforce_missing: true,
@@ -54,6 +55,7 @@ describe('Options', function(){
 
     // Make sure we didn't messed up the global options
     assert.deepEqual(thinky.getOptions(), {
+      pingInterval: -1,
       timeFormat: 'raw',
       enforce_extra: 'strict',
       enforce_missing: true,
@@ -93,6 +95,7 @@ describe('Options', function(){
     var Model = thinky.createModel(name, {id: String, name: String});
 
     var doc = new Model({}, {
+      pingInterval: -1,
       timeFormat: 'raw',
       enforce_extra: 'none',
       enforce_missing: false,
@@ -107,6 +110,7 @@ describe('Options', function(){
 
     // Make sure we didn't messed up the global options
     assert.deepEqual(thinky.getOptions(), {
+      pingInterval: -1,
       timeFormat: 'raw',
       enforce_extra: 'strict',
       enforce_missing: true,


### PR DESCRIPTION
The server is closing connection after a time, which makes can cause
errors in several environments.

This commit adds a new config option when initializing thinky, which
will help keeping the connection alive, using `rethinkdbdash`'s solution
with the same input.

- `pingInterval`: - if `> 0`, the connection will be pinged every
  `pingInterval` seconds, default `-1`
  https://github.com/neumino/rethinkdbdash

It was implemented following this discussion, which describes the issue
pretty well:
https://github.com/neumino/rethinkdbdash/issues/192#issuecomment-212753388