### PR TITLE
Add _rel option to getJoin

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -308,8 +308,8 @@ Query.prototype._convertGroupedData = function(data) {
   }
 }
 
-function extendQueryWithJoin(doc, model, joinName, join, getAll, r, ifPresent, ifMissing) {
-  var innerQuery;
+function queryForJoin(doc, model, joinName, join, ifPresent, ifMissing) {
+  var innerQuery, r = join.model._thinky.r
 
   switch (join.type) {
     case 'hasOne':
@@ -356,6 +356,39 @@ function extendQueryWithJoin(doc, model, joinName, join, getAll, r, ifPresent, i
   }
 }
 
+Query.prototype._getOneJoin = function(key, joins, modelToGet, getAll, gotModel) {
+  var self = this;
+  var r = self._model._getModel()._thinky.r;
+  var model = this._model;
+
+  var join = joins[key]
+  var subJoin = modelToGet[key]
+
+  self._query = self._query.merge(function(doc) {
+    return doc.hasFields(join.leftKey).branch(
+      queryForJoin(doc, model, key, join,
+        function(subQuery) {
+          if ((subJoin != null) && (typeof subJoin._apply === 'function')) {
+            subQuery = subJoin._apply(subQuery);
+          }
+
+          if (join.type != 'hasOne' && 
+              join.type != 'belongsTo' && 
+              (subJoin == null || subJoin._array !== false)) {
+            subQuery = subQuery.coerceTo("ARRAY");
+          }
+
+          subQuery = subQuery.getJoin(subJoin, getAll, gotModel)._query;
+
+          return r.object(key, subQuery)
+        },
+        function() { return {} }
+      ),
+      {}
+    )
+  })
+}
+
 /**
  * Perform a join given the relations on this._model
  * @param {Object=} modelToGet explicit joined documents to retrieve
@@ -367,7 +400,6 @@ function extendQueryWithJoin(doc, model, joinName, join, getAll, r, ifPresent, i
  */
 Query.prototype.getJoin = function(modelToGet, getAll, gotModel) {
   var self = this;
-  var r = self._model._getModel()._thinky.r;
 
   var model = this._model;
   var joins = this._model._getModel()._joins;
@@ -381,35 +413,8 @@ Query.prototype.getJoin = function(modelToGet, getAll, gotModel) {
   gotModel[model.getTableName()] = true;
 
   util.loopKeys(joins, function(joins, key) {
-    var join = joins[key]
-    if ((util.isPlainObject(modelToGet) && modelToGet.hasOwnProperty(key))
-        ||
-        ((getAll === true) && (gotModel[join.model.getTableName()] !== true))) {
-      self._query = self._query.merge(function(doc) {
-        return doc.hasFields(join.leftKey).branch(
-          extendQueryWithJoin(doc, model, key, join, getAll, r,
-            function(subQuery) {
-              var subJoin = modelToGet[key]
-
-              if ((subJoin != null) && (typeof subJoin._apply === 'function')) {
-                subQuery = subJoin._apply(subQuery);
-              }
-
-              if (join.type != 'hasOne' && 
-                  join.type != 'belongsTo' && 
-                  (subJoin == null || subJoin._array !== false)) {
-                subQuery = subQuery.coerceTo("ARRAY");
-              }
-
-              subQuery = subQuery.getJoin(modelToGet[key], getAll, gotModel)._query;
-
-              return r.object(key, subQuery)
-            },
-            function() { return {} }
-          ),
-          {}
-        )
-      })
+    if (util.recurse(key, joins, modelToGet, getAll, gotModel)) {
+      self._getOneJoin(key, joins, modelToGet, getAll, gotModel)
     }
   });
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -361,32 +361,35 @@ Query.prototype._getOneJoin = function(key, joins, modelToGet, getAll, gotModel)
   var r = self._model._getModel()._thinky.r;
   var model = this._model;
 
-  var join = joins[key]
   var subJoin = modelToGet[key]
+  var relation = subJoin && subJoin._rel || key
+  var join = joins[relation]
 
-  self._query = self._query.merge(function(doc) {
-    return doc.hasFields(join.leftKey).branch(
-      queryForJoin(doc, model, key, join,
-        function(subQuery) {
-          if ((subJoin != null) && (typeof subJoin._apply === 'function')) {
-            subQuery = subJoin._apply(subQuery);
-          }
+  if (join) {
+    self._query = self._query.merge(function(doc) {
+      return doc.hasFields(join.leftKey).branch(
+        queryForJoin(doc, model, key, join,
+          function(subQuery) {
+            if ((subJoin != null) && (typeof subJoin._apply === 'function')) {
+              subQuery = subJoin._apply(subQuery);
+            }
 
-          if (join.type != 'hasOne' && 
-              join.type != 'belongsTo' && 
-              (subJoin == null || subJoin._array !== false)) {
-            subQuery = subQuery.coerceTo("ARRAY");
-          }
+            if (join.type != 'hasOne' && 
+                join.type != 'belongsTo' && 
+                (subJoin == null || subJoin._array !== false)) {
+              subQuery = subQuery.coerceTo("ARRAY");
+            }
 
-          subQuery = subQuery.getJoin(subJoin, getAll, gotModel)._query;
+            subQuery = subQuery.getJoin(subJoin, getAll, gotModel)._query;
 
-          return r.object(key, subQuery)
-        },
-        function() { return {} }
-      ),
-      {}
-    )
-  })
+            return r.object(key, subQuery)
+          },
+          function() { return {} }
+        ),
+        {}
+      )
+    })
+  }
 }
 
 /**
@@ -412,11 +415,22 @@ Query.prototype.getJoin = function(modelToGet, getAll, gotModel) {
   gotModel = gotModel || {};
   gotModel[model.getTableName()] = true;
 
-  util.loopKeys(joins, function(joins, key) {
-    if (util.recurse(key, joins, modelToGet, getAll, gotModel)) {
-      self._getOneJoin(key, joins, modelToGet, getAll, gotModel)
-    }
-  });
+  if (getAll) {
+    util.loopKeys(joins, function(joins, key) {
+      if (util.recurse(key, joins, modelToGet, getAll, gotModel)) {
+        self._getOneJoin(key, joins, modelToGet, getAll, gotModel)
+      }
+    });
+  } else {
+    util.loopKeys(modelToGet, function(_, key) {
+      if (key != '_apply' &&
+          key != '_array' && 
+          key != '_rel' &&
+          util.recurse(key, joins, modelToGet, getAll, gotModel)) {
+        self._getOneJoin(key, joins, modelToGet, getAll, gotModel)
+      }
+    });
+  }
 
   return self;
 };

--- a/lib/query.js
+++ b/lib/query.js
@@ -308,39 +308,31 @@ Query.prototype._convertGroupedData = function(data) {
   }
 }
 
-function extendQueryWithJoin(query, model, joinName, join, subJoin, getAll, gotModel, r) {
+function extendQueryWithJoin(doc, model, joinName, join, subJoin, getAll, gotModel, r, ifPresent, ifMissing) {
   var innerQuery;
 
   switch (join.type) {
   case 'hasOne':
   case 'belongsTo':
-    return query.merge(function(doc) {
-      return r.branch(
-        doc.hasFields(join.leftKey),
-        r.table(join.model.getTableName()).getAll(doc(join.leftKey), {index: join.rightKey}).coerceTo("ARRAY").do(function(result) {
-          innerQuery = new Query(join.model, result.nth(0));
+      return r.table(join.model.getTableName()).getAll(doc(join.leftKey), {index: join.rightKey}).coerceTo("ARRAY").do(function(result) {
+        innerQuery = new Query(join.model, result.nth(0));
 
-          if ((subJoin != null) && (typeof subJoin._apply === 'function')) {
-            innerQuery = subJoin._apply(innerQuery);
-          }
-          innerQuery = innerQuery.getJoin(subJoin, getAll, gotModel)._query;
-          return r.branch(
-            result.count().eq(1),
-            r.object(joinName, innerQuery),
-            r.branch(
-              result.count().eq(0),
-              {},
-              r.error(r.expr("More than one element found for ").add(doc.coerceTo("STRING")).add(r.expr("for the field ").add(joinName)))
-            )
+        if ((subJoin != null) && (typeof subJoin._apply === 'function')) {
+          innerQuery = subJoin._apply(innerQuery);
+        }
+        innerQuery = innerQuery.getJoin(subJoin, getAll, gotModel)._query;
+        return r.branch(
+          result.count().eq(1),
+          ifPresent(innerQuery),
+          r.branch(
+            result.count().eq(0),
+            ifMissing(),
+            r.error(r.expr("More than one element found for ").add(doc.coerceTo("STRING")).add(r.expr("for the field ").add(joinName)))
           )
-        }),
-        {}
-      )
-    });
-    break;
+        )
+      })
 
   case 'hasMany':
-    return query.merge(function(doc) {
       innerQuery = new Query(join.model,
                   r.table(join.model.getTableName())
                 .getAll(doc(join.leftKey), {index: join.rightKey}))
@@ -354,16 +346,9 @@ function extendQueryWithJoin(query, model, joinName, join, subJoin, getAll, gotM
       }
       innerQuery = innerQuery._query;
 
-      return r.branch(
-        doc.hasFields(join.leftKey),
-        r.object(joinName, innerQuery),
-        {}
-      )
-    });
-    break;
+      return ifPresent(innerQuery);
 
   case 'hasAndBelongsToMany':
-    return query.merge(function(doc) {
       if ((model.getTableName() === join.model.getTableName()) && (join.leftKey === join.rightKey)) {
         // In case the model is linked with itself on the same key
 
@@ -385,11 +370,7 @@ function extendQueryWithJoin(query, model, joinName, join, subJoin, getAll, gotM
           innerQuery = innerQuery.coerceTo("ARRAY");
         }
 
-        return r.branch(
-          doc.hasFields(join.leftKey),
-          r.object(joinName, new Query(join.model, innerQuery).getJoin(subJoin, getAll, gotModel)._query),
-          {}
-        )
+        return ifPresent(new Query(join.model, innerQuery).getJoin(subJoin, getAll, gotModel)._query);
       }
       else {
         innerQuery = r.table(join.link).getAll(doc(join.leftKey), {index: model.getTableName()+"_"+join.leftKey}).concatMap(function(link) {
@@ -404,15 +385,8 @@ function extendQueryWithJoin(query, model, joinName, join, subJoin, getAll, gotM
           innerQuery = innerQuery.coerceTo("ARRAY");
         }
 
-        return r.branch(
-          doc.hasFields(join.leftKey),
-          r.object(joinName,
-            new Query(join.model, innerQuery).getJoin(subJoin, getAll, gotModel)._query),
-          {}
-        )
+        return ifPresent(new Query(join.model, innerQuery).getJoin(subJoin, getAll, gotModel)._query);
       }
-    });
-    break;
   }
 }
 
@@ -442,10 +416,19 @@ Query.prototype.getJoin = function(modelToGet, getAll, gotModel) {
   gotModel[model.getTableName()] = true;
 
   util.loopKeys(joins, function(joins, key) {
+    var join = joins[key]
     if ((util.isPlainObject(modelToGet) && modelToGet.hasOwnProperty(key))
         ||
-        ((getAll === true) && (gotModel[joins[key].model.getTableName()] !== true))) {
-      self._query = extendQueryWithJoin(self._query, model, key, joins[key], modelToGet[key], getAll, gotModel, r)
+        ((getAll === true) && (gotModel[join.model.getTableName()] !== true))) {
+      self._query = self._query.merge(function(doc) {
+        return doc.hasFields(join.leftKey).branch(
+          extendQueryWithJoin(doc, model, key, join, modelToGet[key], getAll, gotModel, r,
+            function(subQuery) { return r.object(key, subQuery) },
+            function() { return {} }
+          ),
+          {}
+        )
+      })
     }
   });
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -308,6 +308,114 @@ Query.prototype._convertGroupedData = function(data) {
   }
 }
 
+function extendQueryWithJoin(query, model, joinName, join, subJoin, getAll, gotModel, r) {
+  var innerQuery;
+
+  switch (join.type) {
+  case 'hasOne':
+  case 'belongsTo':
+    return query.merge(function(doc) {
+      return r.branch(
+        doc.hasFields(join.leftKey),
+        r.table(join.model.getTableName()).getAll(doc(join.leftKey), {index: join.rightKey}).coerceTo("ARRAY").do(function(result) {
+          innerQuery = new Query(join.model, result.nth(0));
+
+          if ((subJoin != null) && (typeof subJoin._apply === 'function')) {
+            innerQuery = subJoin._apply(innerQuery);
+          }
+          innerQuery = innerQuery.getJoin(subJoin, getAll, gotModel)._query;
+          return r.branch(
+            result.count().eq(1),
+            r.object(joinName, innerQuery),
+            r.branch(
+              result.count().eq(0),
+              {},
+              r.error(r.expr("More than one element found for ").add(doc.coerceTo("STRING")).add(r.expr("for the field ").add(joinName)))
+            )
+          )
+        }),
+        {}
+      )
+    });
+    break;
+
+  case 'hasMany':
+    return query.merge(function(doc) {
+      innerQuery = new Query(join.model,
+                  r.table(join.model.getTableName())
+                .getAll(doc(join.leftKey), {index: join.rightKey}))
+
+      if ((subJoin != null) && (typeof subJoin._apply === 'function')) {
+        innerQuery = subJoin._apply(innerQuery);
+      }
+      innerQuery = innerQuery.getJoin(subJoin, getAll, gotModel);
+      if ((subJoin == null) || (subJoin._array !== false)) {
+        innerQuery = innerQuery.coerceTo("ARRAY");
+      }
+      innerQuery = innerQuery._query;
+
+      return r.branch(
+        doc.hasFields(join.leftKey),
+        r.object(joinName, innerQuery),
+        {}
+      )
+    });
+    break;
+
+  case 'hasAndBelongsToMany':
+    return query.merge(function(doc) {
+      if ((model.getTableName() === join.model.getTableName()) && (join.leftKey === join.rightKey)) {
+        // In case the model is linked with itself on the same key
+
+        innerQuery = r.table(join.link).getAll(doc(join.leftKey), {index: join.leftKey+"_"+join.leftKey}).concatMap(function(link) {
+          return r.table(join.model.getTableName()).getAll(
+            r.branch(
+              doc(join.leftKey).eq(link(join.leftKey+"_"+join.leftKey).nth(0)),
+              link(join.leftKey+"_"+join.leftKey).nth(1),
+              link(join.leftKey+"_"+join.leftKey).nth(0)
+            )
+          , {index: join.rightKey})
+        });
+
+        if ((subJoin != null) && (typeof subJoin._apply === 'function')) {
+          innerQuery = subJoin._apply(innerQuery);
+        }
+
+        if ((subJoin == null) || (subJoin._array !== false)) {
+          innerQuery = innerQuery.coerceTo("ARRAY");
+        }
+
+        return r.branch(
+          doc.hasFields(join.leftKey),
+          r.object(joinName, new Query(join.model, innerQuery).getJoin(subJoin, getAll, gotModel)._query),
+          {}
+        )
+      }
+      else {
+        innerQuery = r.table(join.link).getAll(doc(join.leftKey), {index: model.getTableName()+"_"+join.leftKey}).concatMap(function(link) {
+          return r.table(join.model.getTableName()).getAll(link(join.model.getTableName()+"_"+join.rightKey), {index: join.rightKey})
+        });
+
+        if ((subJoin != null) && (typeof subJoin._apply === 'function')) {
+          innerQuery = subJoin._apply(innerQuery)
+        }
+
+        if ((subJoin == null) || (subJoin._array !== false)) {
+          innerQuery = innerQuery.coerceTo("ARRAY");
+        }
+
+        return r.branch(
+          doc.hasFields(join.leftKey),
+          r.object(joinName,
+            new Query(join.model, innerQuery).getJoin(subJoin, getAll, gotModel)._query),
+          {}
+        )
+      }
+    });
+    break;
+  }
+}
+
 
 /**
  * Perform a join given the relations on this._model
@@ -329,116 +437,15 @@ Query.prototype.getJoin = function(modelToGet, getAll, gotModel) {
   if (util.isPlainObject(modelToGet) === false) {
     modelToGet = {};
   }
-  var innerQuery;
 
   gotModel = gotModel || {};
   gotModel[model.getTableName()] = true;
 
   util.loopKeys(joins, function(joins, key) {
-    if (util.recurse(key, joins, modelToGet, getAll, gotModel)) {
-      switch (joins[key].type) {
-        case 'hasOne':
-        case 'belongsTo':
-          self._query = self._query.merge(function(doc) {
-            return r.branch(
-              doc.hasFields(joins[key].leftKey),
-              r.table(joins[key].model.getTableName()).getAll(doc(joins[key].leftKey), {index: joins[key].rightKey}).coerceTo("ARRAY").do(function(result) {
-                innerQuery = new Query(joins[key].model, result.nth(0));
-
-                if ((modelToGet[key] != null) && (typeof modelToGet[key]._apply === 'function')) {
-                  innerQuery = modelToGet[key]._apply(innerQuery);
-                }
-                innerQuery = innerQuery.getJoin(modelToGet[key], getAll, gotModel)._query;
-                return r.branch(
-                  result.count().eq(1),
-                  r.object(key, innerQuery),
-                  r.branch(
-                    result.count().eq(0),
-                    {},
-                    r.error(r.expr("More than one element found for ").add(doc.coerceTo("STRING")).add(r.expr("for the field ").add(key)))
-                  )
-                )
-              }),
-              {}
-            )
-          });
-          break;
-
-        case 'hasMany':
-          self._query = self._query.merge(function(doc) {
-            innerQuery = new Query(joins[key].model,
-                       r.table(joins[key].model.getTableName())
-                      .getAll(doc(joins[key].leftKey), {index: joins[key].rightKey}))
-
-            if ((modelToGet[key] != null) && (typeof modelToGet[key]._apply === 'function')) {
-              innerQuery = modelToGet[key]._apply(innerQuery);
-            }
-            innerQuery = innerQuery.getJoin(modelToGet[key], getAll, gotModel);
-            if ((modelToGet[key] == null) || (modelToGet[key]._array !== false)) {
-              innerQuery = innerQuery.coerceTo("ARRAY");
-            }
-            innerQuery = innerQuery._query;
-
-            return r.branch(
-              doc.hasFields(joins[key].leftKey),
-              r.object(key, innerQuery),
-              {}
-            )
-          });
-          break;
-
-        case 'hasAndBelongsToMany':
-          self._query = self._query.merge(function(doc) {
-            if ((model.getTableName() === joins[key].model.getTableName()) && (joins[key].leftKey === joins[key].rightKey)) {
-              // In case the model is linked with itself on the same key
-
-              innerQuery = r.table(joins[key].link).getAll(doc(joins[key].leftKey), {index: joins[key].leftKey+"_"+joins[key].leftKey}).concatMap(function(link) {
-                return r.table(joins[key].model.getTableName()).getAll(
-                  r.branch(
-                    doc(joins[key].leftKey).eq(link(joins[key].leftKey+"_"+joins[key].leftKey).nth(0)),
-                    link(joins[key].leftKey+"_"+joins[key].leftKey).nth(1),
-                    link(joins[key].leftKey+"_"+joins[key].leftKey).nth(0)
-                  )
-                , {index: joins[key].rightKey})
-              });
-
-              if ((modelToGet[key] != null) && (typeof modelToGet[key]._apply === 'function')) {
-                innerQuery = modelToGet[key]._apply(innerQuery);
-              }
-
-              if ((modelToGet[key] == null) || (modelToGet[key]._array !== false)) {
-                innerQuery = innerQuery.coerceTo("ARRAY");
-              }
-
-              return r.branch(
-                doc.hasFields(joins[key].leftKey),
-                r.object(key, new Query(joins[key].model, innerQuery).getJoin(modelToGet[key], getAll, gotModel)._query),
-                {}
-              )
-            }
-            else {
-              innerQuery = r.table(joins[key].link).getAll(doc(joins[key].leftKey), {index: model.getTableName()+"_"+joins[key].leftKey}).concatMap(function(link) {
-                return r.table(joins[key].model.getTableName()).getAll(link(joins[key].model.getTableName()+"_"+joins[key].rightKey), {index: joins[key].rightKey})
-              });
-
-              if ((modelToGet[key] != null) && (typeof modelToGet[key]._apply === 'function')) {
-                innerQuery = modelToGet[key]._apply(innerQuery)
-              }
-
-              if ((modelToGet[key] == null) || (modelToGet[key]._array !== false)) {
-                innerQuery = innerQuery.coerceTo("ARRAY");
-              }
-
-              return r.branch(
-                doc.hasFields(joins[key].leftKey),
-                r.object(key,
-                  new Query(joins[key].model, innerQuery).getJoin(modelToGet[key], getAll, gotModel)._query),
-                {}
-              )
-            }
-          });
-          break;
-      }
+    if ((util.isPlainObject(modelToGet) && modelToGet.hasOwnProperty(key))
+        ||
+        ((getAll === true) && (gotModel[joins[key].model.getTableName()] !== true))) {
+      self._query = extendQueryWithJoin(self._query, model, key, joins[key], modelToGet[key], getAll, gotModel, r)
     }
   });
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -308,47 +308,32 @@ Query.prototype._convertGroupedData = function(data) {
   }
 }
 
-function extendQueryWithJoin(doc, model, joinName, join, subJoin, getAll, gotModel, r, ifPresent, ifMissing) {
+function extendQueryWithJoin(doc, model, joinName, join, getAll, r, ifPresent, ifMissing) {
   var innerQuery;
 
   switch (join.type) {
-  case 'hasOne':
-  case 'belongsTo':
+    case 'hasOne':
+    case 'belongsTo':
       return r.table(join.model.getTableName()).getAll(doc(join.leftKey), {index: join.rightKey}).coerceTo("ARRAY").do(function(result) {
         innerQuery = new Query(join.model, result.nth(0));
 
-        if ((subJoin != null) && (typeof subJoin._apply === 'function')) {
-          innerQuery = subJoin._apply(innerQuery);
-        }
-        innerQuery = innerQuery.getJoin(subJoin, getAll, gotModel)._query;
-        return r.branch(
-          result.count().eq(1),
+        return result.count().eq(1).branch(
           ifPresent(innerQuery),
-          r.branch(
-            result.count().eq(0),
+          result.count().eq(0).branch(
             ifMissing(),
             r.error(r.expr("More than one element found for ").add(doc.coerceTo("STRING")).add(r.expr("for the field ").add(joinName)))
           )
         )
       })
 
-  case 'hasMany':
+    case 'hasMany':
       innerQuery = new Query(join.model,
                   r.table(join.model.getTableName())
                 .getAll(doc(join.leftKey), {index: join.rightKey}))
 
-      if ((subJoin != null) && (typeof subJoin._apply === 'function')) {
-        innerQuery = subJoin._apply(innerQuery);
-      }
-      innerQuery = innerQuery.getJoin(subJoin, getAll, gotModel);
-      if ((subJoin == null) || (subJoin._array !== false)) {
-        innerQuery = innerQuery.coerceTo("ARRAY");
-      }
-      innerQuery = innerQuery._query;
-
       return ifPresent(innerQuery);
 
-  case 'hasAndBelongsToMany':
+    case 'hasAndBelongsToMany':
       if ((model.getTableName() === join.model.getTableName()) && (join.leftKey === join.rightKey)) {
         // In case the model is linked with itself on the same key
 
@@ -361,35 +346,15 @@ function extendQueryWithJoin(doc, model, joinName, join, subJoin, getAll, gotMod
             )
           , {index: join.rightKey})
         });
-
-        if ((subJoin != null) && (typeof subJoin._apply === 'function')) {
-          innerQuery = subJoin._apply(innerQuery);
-        }
-
-        if ((subJoin == null) || (subJoin._array !== false)) {
-          innerQuery = innerQuery.coerceTo("ARRAY");
-        }
-
-        return ifPresent(new Query(join.model, innerQuery).getJoin(subJoin, getAll, gotModel)._query);
       }
       else {
         innerQuery = r.table(join.link).getAll(doc(join.leftKey), {index: model.getTableName()+"_"+join.leftKey}).concatMap(function(link) {
           return r.table(join.model.getTableName()).getAll(link(join.model.getTableName()+"_"+join.rightKey), {index: join.rightKey})
         });
-
-        if ((subJoin != null) && (typeof subJoin._apply === 'function')) {
-          innerQuery = subJoin._apply(innerQuery)
-        }
-
-        if ((subJoin == null) || (subJoin._array !== false)) {
-          innerQuery = innerQuery.coerceTo("ARRAY");
-        }
-
-        return ifPresent(new Query(join.model, innerQuery).getJoin(subJoin, getAll, gotModel)._query);
       }
+      return ifPresent(new Query(join.model, innerQuery));
   }
 }
-
 
 /**
  * Perform a join given the relations on this._model
@@ -422,8 +387,24 @@ Query.prototype.getJoin = function(modelToGet, getAll, gotModel) {
         ((getAll === true) && (gotModel[join.model.getTableName()] !== true))) {
       self._query = self._query.merge(function(doc) {
         return doc.hasFields(join.leftKey).branch(
-          extendQueryWithJoin(doc, model, key, join, modelToGet[key], getAll, gotModel, r,
-            function(subQuery) { return r.object(key, subQuery) },
+          extendQueryWithJoin(doc, model, key, join, getAll, r,
+            function(subQuery) {
+              var subJoin = modelToGet[key]
+
+              if ((subJoin != null) && (typeof subJoin._apply === 'function')) {
+                subQuery = subJoin._apply(subQuery);
+              }
+
+              if (join.type != 'hasOne' && 
+                  join.type != 'belongsTo' && 
+                  (subJoin == null || subJoin._array !== false)) {
+                subQuery = subQuery.coerceTo("ARRAY");
+              }
+
+              subQuery = subQuery.getJoin(modelToGet[key], getAll, gotModel)._query;
+
+              return r.object(key, subQuery)
+            },
             function() { return {} }
           ),
           {}


### PR DESCRIPTION
Say we have a forum with posts:

```
Forum.get(forumId).getJoin({posts: true})

// Only recent posts
Forum.get(forumId).getJoin({
  posts: {_apply: posts => posts.orderBy(r.desc('createdAt').limit(10)}
})
```

What if we want recent posts _and_ pinned posts?. The `_rel` option lets 
you specify the name of the relation, so it can differ from the the attribute to be merged.

```
Forum.get(forumId).getJoin({
  posts: {_apply: posts => posts.orderBy(r.desc('createdAt').limit(10)},
  pinnedPosts {_rel: 'posts', _apply: posts => posts.filter(p => p('pinned'))}
})
```

Another example - fetch a count along with the posts:

```
Forum.get(forumId).getJoin({
  posts: {_apply: p => p.orderBy(r.desc('createdAt').limit(10)},
  postsCount: {_rel: 'posts', _apply: p => p.count(), _array: false} 
})
```

If you like the feature but there is something lacking in the PR, please let me know and I'll work
on it.
