### PR TITLE
Fixing hasAndBelongsToMany shard/replica configuration

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -558,7 +558,9 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
 
   var linkModel;
   if (thinky.models[link] === undefined) {
-    linkModel = thinky.createModel(link, {}, { table: self._table }); // Create a model, claim the namespace and create the table
+    // Create a model, claim the namespace and create the table
+    // passes table options to the underlying model (e.g. replicas, shards)
+    linkModel = thinky.createModel(link, {}, { table: options.table });
   }
   else {
     linkModel = thinky.models[link];

--- a/lib/model.js
+++ b/lib/model.js
@@ -558,7 +558,7 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
 
   var linkModel;
   if (thinky.models[link] === undefined) {
-    linkModel = thinky.createModel(link, {}); // Create a model, claim the namespace and create the table
+    linkModel = thinky.createModel(link, {}, { table: self._table }); // Create a model, claim the namespace and create the table
   }
   else {
     linkModel = thinky.models[link];


### PR DESCRIPTION
This PR fixes an issue Tables created by adding a `hasAndBelongsToMany` relation do not properly "inherit" the table configuration from the parent model.

For example, when running a production RethinkDB instance, I configure all the models (and therefore the tables) to have 3 replicas. Tables that are created as a result of the `hasAndBelongsToMany` relation always have 1 replica and 1 shard.