### PR TITLE
Upgrade bluebird to 3.x (take two)

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -562,7 +562,7 @@ Document.prototype._save = function(docToSave, saveAll, savedModel, callback) {
     async: true,
     fn: self._saveHook,
     fnArgs: [docToSave, saveAll, savedModel]
-  }).nodeify(callback);
+  }).asCallback(callback);
 }
 
 
@@ -664,7 +664,7 @@ Document.prototype._saveHook = function(docToSave, saveAll, savedModel) {
     self.getModel().ready().then(function() {
       Promise.all(promises).then(function() {
         self._onSavedBelongsTo(copy, docToSave, belongsToKeysSaved, saveAll, savedModel, resolve, reject);
-      }).error(reject);
+      }).catch(reject);
     });
   });
   return p;
@@ -781,14 +781,14 @@ Document.prototype._saveSelf = function(
           querySaveSelf = buildQuery();
           querySaveSelf.run().then(function(result) {
             self._onSaved(result, docToSave, saveAll, savedModel, resolve, reject)
-          }).error(reject)
-        }).error(reject);
+          }).catch(reject)
+        }).catch(reject);
       }
       else {
         querySaveSelf = buildQuery();
         querySaveSelf.run().then(function(result) {
           self._onSaved(result, docToSave, saveAll, savedModel, resolve, reject)
-        }).error(reject)
+        }).catch(reject)
       }
     }, reject);
   });
@@ -828,7 +828,7 @@ Document.prototype._onSaved = function(result, docToSave, saveAll, savedModel, r
     if (promise instanceof Promise) {
       promise.then(function() {
         self._saveMany(docToSave, saveAll, savedModel, resolve, reject)
-      }).error(reject);
+      }).catch(reject);
     }
     else {
       self._saveMany(docToSave, saveAll, savedModel, resolve, reject)
@@ -875,7 +875,7 @@ Document.prototype._saveMany = function(docToSave, saveAll, savedModel, resolve,
                 key: key
               });
               resolve();
-            }).error(reject);
+            }).catch(reject);
           }))
         })(key)
       }
@@ -941,11 +941,11 @@ Document.prototype._saveMany = function(docToSave, saveAll, savedModel, resolve,
                 });
 
                 resolve();
-              }).error(reject);
+              }).catch(reject);
             }
 
             if (self[key][i] instanceof Promise) {
-              self[key][i].then(callback).error(reject);
+              self[key][i].then(callback).catch(reject);
             }
             else {
               callback();
@@ -982,11 +982,11 @@ Document.prototype._saveMany = function(docToSave, saveAll, savedModel, resolve,
                       key: key
                     });
                     resolve();
-                  }).error(reject);
+                  }).catch(reject);
                 }
 
                 if (self[key][i] instanceof Promise) {
-                  self[key][i].then(callback).error(reject);
+                  self[key][i].then(callback).catch(reject);
                 }
                 else {
                   callback();
@@ -1002,7 +1002,7 @@ Document.prototype._saveMany = function(docToSave, saveAll, savedModel, resolve,
   if (promisesMany.length > 0) {
     Promise.all(promisesMany).then(function() {
       self._saveLinks(docToSave, saveAll, resolve, reject)
-    }).error(reject);
+    }).catch(reject);
   }
   else {
     self._saveLinks(docToSave, saveAll, resolve, reject)
@@ -1097,7 +1097,7 @@ Document.prototype._saveLinks = function(docToSave, saveAll, resolve, reject) {
                     self.__proto__._links[joins[key].link][newLink[joins[key].model.getTableName()+"_"+joins[key].rightKey]] = true;
                   }
                   resolve();
-                }).error(reject);
+                }).catch(reject);
               }))
             })(key, link);
           }
@@ -1129,7 +1129,7 @@ Document.prototype._saveLinks = function(docToSave, saveAll, resolve, reject) {
   if (promisesLink.length > 0) {
     Promise.all(promisesLink).then(function() {
       resolve(self);
-    }).error(reject);
+    }).catch(reject);
   }
   else {
     resolve(self);
@@ -1410,7 +1410,7 @@ Document.prototype._deleteHook = function(docToDelete, deleteAll, deletedDocs, d
             self[key]._delete(docToDelete[key], deleteAll, deletedDocs, true, false).then(function() {
               delete self[key];
               resolve();
-            }).error(reject);
+            }).catch(reject);
           }))
         })(key);
       }
@@ -1430,7 +1430,7 @@ Document.prototype._deleteHook = function(docToDelete, deleteAll, deletedDocs, d
             self[key]._delete(docToDelete[key], deleteAll, deletedDocs, true, false).then(function() {
               delete self[key];
               resolve();
-            }).error(reject);
+            }).catch(reject);
           }));
         })(key);
       }
@@ -1580,7 +1580,7 @@ Document.prototype._deleteHook = function(docToDelete, deleteAll, deletedDocs, d
           self._setUnSaved();
           self.emit('deleted', self);
           resolve(self);
-        }).error(reject);
+        }).catch(reject);
       }))
     }
     // else we don't throw an error, should we?
@@ -1589,11 +1589,11 @@ Document.prototype._deleteHook = function(docToDelete, deleteAll, deletedDocs, d
   var p = new Promise(function(resolve, reject) {
     Promise.all(promises).then(function(result) {
       resolve(self);
-    }).error(function(error) {
+    }).catch(function(error) {
       reject(error)
     });
   })
-  return p.nodeify(callback);
+  return p.asCallback(callback);
 }
 
 /*
@@ -1702,8 +1702,8 @@ Document.prototype.purge = function(callback) {
   return new Promise(function(resolve, reject) {
     Promise.all(promises).then(function() {
       resolve(self);
-    }).error(reject);
-  }).nodeify(callback);
+    }).catch(reject);
+  }).asCallback(callback);
 }
 
 Document.prototype.addRelation = function() {

--- a/lib/feed.js
+++ b/lib/feed.js
@@ -25,19 +25,19 @@ Feed.prototype._next = function() {
           self.model._parse(data.new_val).then(function(doc) {
             doc._setOldValue(data.old_val);
             resolve(doc);
-          }).error(reject);
+          }).catch(reject);
         }
         else if (data.old_val != null) { // new_val is null
           self.model._parse(data.old_val).then(function(doc) {
             doc._setUnSaved();
             resolve(doc);
-          }).error(reject);
+          }).catch(reject);
         }
         //else we just drop the change as it's a state/initializing object
       }, function(err) {
         reject(err);
       })
-    }).error(reject);
+    }).catch(reject);
   });
 }
 
@@ -64,7 +64,7 @@ Feed.prototype._each = function(callback, onFinish) {
         self.model._parse(data.new_val).then(function(doc) {
           doc._setOldValue(data.old_val);
           callback(null, doc);
-        }).error(function(err) {
+        }).catch(function(err) {
           callback(err);
         });
       }
@@ -72,7 +72,7 @@ Feed.prototype._each = function(callback, onFinish) {
         self.model._parse(data.old_val).then(function(doc) {
           doc._setUnSaved();
           callback(null, doc);
-        }).error(function(err) {
+        }).catch(function(err) {
           callback(err);
         });
       }
@@ -110,7 +110,7 @@ Feed.prototype._eachCb = function(err, data) {
       self.model._parse(data.new_val).then(function(doc) {
         doc._setOldValue(data.old_val);
         self._eventEmitter.emit('data', doc);
-      }).error(function(err) {
+      }).catch(function(err) {
         self._eventEmitter.emit('error', err);
       });
     }
@@ -118,7 +118,7 @@ Feed.prototype._eachCb = function(err, data) {
       self.model._parse(data.old_val).then(function(doc) {
         doc._setUnSaved();
         self._eventEmitter.emit('data', doc);
-      }).error(function(err) {
+      }).catch(function(err) {
         self._eventEmitter.emit('error', err);
       });
     }

--- a/lib/model.js
+++ b/lib/model.js
@@ -207,7 +207,7 @@ Model.prototype.tableReady = function() {
   .then(function() {
     return r.tableCreate(model._name, model._table).run();
   })
-  .error(function(error) {
+  .catch(function(error) {
     if (error.message.match(/Table `.*` already exists/)) {
       return;
     }
@@ -344,7 +344,7 @@ Model.prototype._createIndex = function(name, fn, opts) {
       )
       .run()
       .then(resolve)
-      .error(function(error) {
+      .catch(function(error) {
         if (error.message.match(/^Index/)) {
           // TODO: This regex seems a bit too generous since messages such
           // as "Index `id` was not found on table..." will be accepted.
@@ -627,7 +627,7 @@ Model.prototype.hasAndBelongsToMany = function(joinedModel, fieldDoc, leftKey, r
         self._getModel()._indexes[leftKey] = true;
         joinedModel._getModel()._indexes[rightKey] = true;
       })
-      .error(function(error) {
+      .catch(function(error) {
         if (error.message.match(/^Index `/)) {
           return;
         }
@@ -806,7 +806,7 @@ Model.prototype.save = function(docs, options) {
               rejects[i](new Error("An error occurred during the batch insert. Original results:\n"+JSON.stringify(results, null, 2)));
             }
           }
-        }).error(reject);
+        }).catch(reject);
       }
     };
 
@@ -837,12 +837,12 @@ Model.prototype.save = function(docs, options) {
         for(var i=0; i<docs.length; i++) {
           promises.push(docs[i]._batchSave(executeInsert));
         }
-        Promise.all(promises).then(function() {
-          mainResolve(docs);
-        }).error(function(error) {
-          mainReject(error)
+        return Promise.all(promises).then(function() {
+          return mainResolve(docs);
+        }).catch(function(error) {
+          return mainReject(error)
         });
-      }).error(function(error) {
+      }).catch(function(error) {
         mainReject(new Errors.ValidationError("One of the documents is not valid. Original error:\n"+error.message))
       });
     }
@@ -910,12 +910,12 @@ Model.prototype._parse = function(data, ungroup) {
                 if (promise instanceof Promise) {
                   promise.then(function() {
                     resolve(data)
-                  }).error(reject);
+                  }).catch(reject);
                 }
                 else {
                   resolve(data);
                 }
-              }).error(reject);
+              }).catch(reject);
               promises.push(promise);
             }
             else {
@@ -933,7 +933,7 @@ Model.prototype._parse = function(data, ungroup) {
       if (promises.length > 0) {
         Promise.all(promises).then(function() {
           resolve(data);
-        }).error(reject);
+        }).catch(reject);
       }
       else {
         resolve(data);
@@ -968,12 +968,12 @@ Model.prototype._parse = function(data, ungroup) {
                         if (promise instanceof Promise) {
                           promise.then(function() {
                             resolve(data)
-                          }).error(reject);
+                          }).catch(reject);
                         }
                         else {
                           resolve(data);
                         }
-                      }).error(reject);
+                      }).catch(reject);
                       promises.push(promise);
                     }
                     else {
@@ -1007,12 +1007,12 @@ Model.prototype._parse = function(data, ungroup) {
                     if (promise instanceof Promise) {
                       promise.then(function() {
                         resolve(result)
-                      }).error(reject);
+                      }).catch(reject);
                     }
                     else {
                       resolve(result);
                     }
-                  }).error(reject);
+                  }).catch(reject);
                   promises.push(promise);
                 }
                 else {
@@ -1031,7 +1031,7 @@ Model.prototype._parse = function(data, ungroup) {
         if (promises.length > 0) {
           Promise.all(promises).then(function() {
             resolve(result)
-          }).error(reject);
+          }).catch(reject);
         }
         else {
           resolve(result);
@@ -1060,12 +1060,12 @@ Model.prototype._parse = function(data, ungroup) {
                 if (promise instanceof Promise) {
                   promise.then(function() {
                     resolve(newDoc);
-                  }).error(reject);
+                  }).catch(reject);
                 }
                 else {
                   resolve(newDoc);
                 }
-              }).error(reject);
+              }).catch(reject);
             }
             else {
               promise = newDoc.validate();
@@ -1074,7 +1074,7 @@ Model.prototype._parse = function(data, ungroup) {
             if (promise instanceof Promise) {
               promise.then(function() {
                 resolve(newDoc)
-              }).error(function(err) {
+              }).catch(function(err) {
                 reject(err)
               });
             }

--- a/lib/query.js
+++ b/lib/query.js
@@ -79,7 +79,7 @@ Query.prototype.run = function(options, callback) {
     callback = options;
     options = {};
   }
-  return this._execute(options, true).nodeify(callback);
+  return this._execute(options, true).asCallback(callback);
 }
 
 
@@ -95,7 +95,7 @@ Query.prototype.execute = function(options, callback) {
     callback = options;
     options = {};
   }
-  return this._execute(options, false).nodeify(callback);
+  return this._execute(options, false).asCallback(callback);
 }
 
 /**
@@ -278,7 +278,7 @@ Query.prototype._validateQueryResult = function(result) {
 
       return Promise.all(revertPromises).then(function(result) {
         throw new Error("The write failed, and the changes were reverted.");
-      }).error(function(error) {
+      }).catch(function(error) {
         throw new Error("The write failed, and the attempt to revert the changes failed with the error:\n"+error.message);
       });
     }
@@ -542,14 +542,14 @@ Query.prototype.addRelation = function(field, joinedDocument) {
               return r.object(
                 'id', leftKey.add('_').add(rightKey),
                 model.getTableName()+"_"+joins[field].leftKey, leftKey,
-                joinedModel.getTableName()+"_"+joins[field].rightKey,rightKey 
+                joinedModel.getTableName()+"_"+joins[field].rightKey,rightKey
               )
             }
             else if (model.getTableName() > joinedModel.getTableName()) {
               return r.object(
                 'id', rightKey.add('_').add(leftKey),
                 model.getTableName()+"_"+joins[field].leftKey, leftKey,
-                joinedModel.getTableName()+"_"+joins[field].rightKey,rightKey 
+                joinedModel.getTableName()+"_"+joins[field].rightKey,rightKey
               )
             }
             else {
@@ -558,12 +558,12 @@ Query.prototype.addRelation = function(field, joinedDocument) {
                 r.object(
                   'id', leftKey.add('_').add(rightKey),
                   model.getTableName()+"_"+joins[field].leftKey, leftKey,
-                  joinedModel.getTableName()+"_"+joins[field].rightKey,rightKey 
+                  joinedModel.getTableName()+"_"+joins[field].rightKey,rightKey
                 ),
                 r.object(
                   'id', rightKey.add('_').add(leftKey),
                   model.getTableName()+"_"+joins[field].leftKey, leftKey,
-                  joinedModel.getTableName()+"_"+joins[field].rightKey,rightKey 
+                  joinedModel.getTableName()+"_"+joins[field].rightKey,rightKey
                 )
               )
             }

--- a/lib/thinky.js
+++ b/lib/thinky.js
@@ -58,7 +58,7 @@ function Thinky(config) {
   self.Errors = Errors;
 
   // Initialize the database.
-  self.dbReady().then().error(function(error) {
+  self.dbReady().then().catch(function(error) {
     throw error;
   });
 }
@@ -77,7 +77,7 @@ Thinky.prototype.dbReady = function() {
   }
   this._dbReadyPromise = r.dbCreate(self._config.db)
   .run()
-  .error(function(error) {
+  .catch(function(error) {
     // The `do` is not atomic, we a concurrent query could create the database
     // between the time `dbList` is ran and `dbCreate` is.
     if (error.message.match(/^Database `.*` already exists in/)) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -160,7 +160,7 @@ function _asyncHook(args) {
       return result.then(function(res) {
         result = res;
         executeHooks(0, postHooks, doc, reject, nextPost);
-      }).error(reject);
+      }).catch(reject);
     }
     return executeHooks(0, postHooks, doc, reject, nextPost);
   }

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   "bugs": {
     "url": "https://github.com/neumino/thinky/issues"
   },
-  "dependencies":{
+  "dependencies": {
+    "bluebird": "^3.4.6",
     "rethinkdbdash": "~2.3.0",
-    "bluebird": "~2.10.2",
     "validator": "~3.22.1"
   },
   "devDependencies": {

--- a/test/advanced.js
+++ b/test/advanced.js
@@ -22,7 +22,7 @@ var cleanTables = function(done) {
   for(var name in modelNameSet) {
     promises.push(r.table(name).delete().run());
   }
-  Promise.settle(promises).error(function () {/*ignore*/}).finally(function() {
+  Promise.settle(promises).catch(function () {/*ignore*/}).finally(function() {
     // Add the links table
     for(var model in thinky.models) {
       modelNameSet[model] = true;
@@ -79,7 +79,7 @@ describe('Advanced cases', function(){
             done()
           })
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasOne - belongsTo', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -121,7 +121,7 @@ describe('Advanced cases', function(){
             done()
           })
         });
-      }).error(done);
+      }).catch(done);
     });
     it('belongsTo - hasOne', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -163,7 +163,7 @@ describe('Advanced cases', function(){
             done()
           })
         });
-      }).error(done);
+      }).catch(done);
     });
     it('belongsTo - hasOne -- circular references', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -205,7 +205,7 @@ describe('Advanced cases', function(){
             done()
           })
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasMany - belongsTo', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -263,7 +263,7 @@ describe('Advanced cases', function(){
             done()
           })
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasMany - belongsTo - 2', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -321,7 +321,7 @@ describe('Advanced cases', function(){
             done()
           })
         });
-      }).error(done);
+      }).catch(done);
     })
     it('hasMany - belongsTo', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -378,7 +378,7 @@ describe('Advanced cases', function(){
             done()
           })
         });
-      }).error(done);
+      }).catch(done);
     });
     it('belongsTo - hasMany -- circular references', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -435,7 +435,7 @@ describe('Advanced cases', function(){
             });
           });
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasAndBelongsToMany -- primary keys', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -484,7 +484,7 @@ describe('Advanced cases', function(){
             })
           });
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasAndBelongsToMany -- primary keys - 2', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -534,7 +534,7 @@ describe('Advanced cases', function(){
             })
           });
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasAndBelongsToMany -- multiple saves', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -582,7 +582,7 @@ describe('Advanced cases', function(){
             });
           });
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasAndBelongsToMany -- partial delete', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -637,7 +637,7 @@ describe('Advanced cases', function(){
             });
           });
         });
-      }).error(done);
+      }).catch(done);
     });
 
     it('hasAndBelongsToMany -- primary keys -- circular references', function(done) {
@@ -773,7 +773,7 @@ describe('Advanced cases', function(){
             });
           });
         });
-      }).error(done);
+      }).catch(done);
     });
   });
   describe('deleteAll', function(){
@@ -812,15 +812,15 @@ describe('Advanced cases', function(){
 
         doc.deleteAll().then(function(result) {
 
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
-            OtherModel.get(otherDoc.id).run().error(function(error) {
+            OtherModel.get(otherDoc.id).run().catch(function(error) {
               assert(error instanceof Errors.DocumentNotFound);
               done()
             });
           });
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasOne - belongsTo -- with modelToDelete', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -853,15 +853,15 @@ describe('Advanced cases', function(){
         assert.strictEqual(doc.has, otherDoc);
 
         doc.deleteAll({has: true}).then(function(result) {
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
-            OtherModel.get(otherDoc.id).run().error(function(error) {
+            OtherModel.get(otherDoc.id).run().catch(function(error) {
               assert(error instanceof Errors.DocumentNotFound);
               done()
             });
           });
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasOne - belongsTo -- with empty modelToDelete', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -895,14 +895,14 @@ describe('Advanced cases', function(){
 
         doc.deleteAll({}).then(function(result) {
           return Model.get(doc.id).run()
-        }).error(function(error) {
+        }).catch(function(error) {
           assert(error instanceof Errors.DocumentNotFound);
           return OtherModel.get(otherDoc.id).run();
         }).then(function(result) {
           assert.equal(result.id, otherDoc.id);
           done()
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasOne - belongsTo -- with non matching modelToDelete', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -935,7 +935,7 @@ describe('Advanced cases', function(){
         assert.strictEqual(doc.has, otherDoc);
 
         doc.deleteAll({foo: {bar: true}}).then(function(result) {
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
             OtherModel.get(otherDoc.id).run().then(function(result) {
               assert.equal(result.id, otherDoc.id);
@@ -943,7 +943,7 @@ describe('Advanced cases', function(){
             });
           });
         });
-      }).error(done);
+      }).catch(done);
     });
     it('belongsTo - hasOne -- with no arg', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -977,17 +977,17 @@ describe('Advanced cases', function(){
         assert.strictEqual(otherDoc.belongsTo, doc);
 
         return otherDoc.deleteAll();
-      }).error(done).then(function(result) {
+      }).catch(done).then(function(result) {
         return Model.get(doc.id).run()
-      }).error(function(error) {
+      }).catch(function(error) {
         assert(error instanceof Errors.DocumentNotFound);
         OtherModel.get(otherDoc.id).run().then(function(result) {
           done(new Error("Was expecting the document to be deleted"));
-        }).error(function(error) {
+        }).catch(function(error) {
           assert(error instanceof Errors.DocumentNotFound);
           done()
         });
-      }).error(done);
+      }).catch(done);
     });
     it('belongsTo - hasOne -- with modelToDelete', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -1020,15 +1020,15 @@ describe('Advanced cases', function(){
         assert.strictEqual(otherDoc.belongsTo, doc);
 
         otherDoc.deleteAll({belongsTo: true}).then(function(result) {
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
-            OtherModel.get(otherDoc.id).run().error(function(error) {
+            OtherModel.get(otherDoc.id).run().catch(function(error) {
               assert(error instanceof Errors.DocumentNotFound);
               done()
             });
           });
         });
-      }).error(done);
+      }).catch(done);
     });
     it('belongsTo - hasOne -- with empty modelToDelete', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -1063,13 +1063,13 @@ describe('Advanced cases', function(){
         otherDoc.deleteAll({}).then(function(result) {
           Model.get(doc.id).run().then(function(result) {
             assert.equal(result.id, doc.id);
-            OtherModel.get(otherDoc.id).run().error(function(error) {
+            OtherModel.get(otherDoc.id).run().catch(function(error) {
               assert(error instanceof Errors.DocumentNotFound);
               done()
             });
           });
         });
-      }).error(done);
+      }).catch(done);
     });
 
     it('hasMany - belongsTo', function(done) {
@@ -1118,7 +1118,7 @@ describe('Advanced cases', function(){
 
           assert.equal(doc.isSaved(), false);
 
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
             OtherModel.getAll(doc.id, {index: "otherId"}).run().then(function(result) {
               assert.equal(result.length, 0);
@@ -1126,7 +1126,7 @@ describe('Advanced cases', function(){
             });
           });
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasMany - belongsTo -- empty modelToDelete', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -1168,7 +1168,7 @@ describe('Advanced cases', function(){
         util.sortById(otherDocs);
 
         doc.deleteAll({}).then(function(result) {
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
             OtherModel.getAll(otherDocs[0].id, otherDocs[1].id, otherDocs[2].id, {index: "id"}).run().then(function(result) {
               assert.equal(result.length, 3);
@@ -1180,7 +1180,7 @@ describe('Advanced cases', function(){
           });
         });
 
-      }).error(done);
+      }).catch(done);
     });
     it('hasMany - belongsTo -- good modelToDelete', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -1222,7 +1222,7 @@ describe('Advanced cases', function(){
         util.sortById(otherDocs);
 
         doc.deleteAll({has: true}).then(function(result) {
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
             OtherModel.getAll(otherDocs[0].id, otherDocs[1].id, otherDocs[2].id, {index: "id"}).run().then(function(result) {
               assert.equal(result.length, 0);
@@ -1236,7 +1236,7 @@ describe('Advanced cases', function(){
           });
         });
 
-      }).error(done);
+      }).catch(done);
     });
     it('hasMany - belongsTo -- non matching modelToDelete', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -1278,7 +1278,7 @@ describe('Advanced cases', function(){
         util.sortById(otherDocs);
 
         doc.deleteAll({foo: true}).then(function(result) {
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
             OtherModel.getAll(otherDocs[0].id, otherDocs[1].id, otherDocs[2].id, {index: "id"}).run().then(function(result) {
               assert.equal(result.length, 3);
@@ -1291,7 +1291,7 @@ describe('Advanced cases', function(){
           });
         });
 
-      }).error(done);
+      }).catch(done);
     });
     it('belongsTo - hasMany -- circular references', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -1331,7 +1331,7 @@ describe('Advanced cases', function(){
       }).then(function(result) {
         assert.equal(result, 0);
         done();
-      }).catch(done).error(done);
+      }).catch(done).catch(done);
     });
     it('belongsTo - hasMany -- must manually overwrite', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -1370,7 +1370,7 @@ describe('Advanced cases', function(){
             done();
           });
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasAndBelongsToMany -- primary keys', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -1410,7 +1410,7 @@ describe('Advanced cases', function(){
         assert.equal(otherDoc4.isSaved(), false);
         assert.equal(otherDoc3.isSaved(), true);
         done();
-      }).error(done);
+      }).catch(done);
     });
     it('hasAndBelongsToMany -- primary keys -- bidirectional - 1', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -1457,7 +1457,7 @@ describe('Advanced cases', function(){
 
         assert.equal(doc2.isSaved(), false)
         done();
-      }).error(done);
+      }).catch(done);
     });
     it('hasAndBelongsToMany -- primary keys -- bidirectional - 2', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -1504,7 +1504,7 @@ describe('Advanced cases', function(){
         assert.equal(otherDoc4.isSaved(), false);
 
         done();
-      }).error(done);
+      }).catch(done);
     });
     it('hasAndBelongsToMany -- primary keys -- bidirectional - 3', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -1551,7 +1551,7 @@ describe('Advanced cases', function(){
         assert.equal(otherDoc4.isSaved(), false);
 
         done();
-      }).error(done);
+      }).catch(done);
     });
     it('hasAndBelongsToMany -- not primary keys - 1', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -1597,7 +1597,7 @@ describe('Advanced cases', function(){
         assert.equal(otherDoc3.isSaved(), true);
         assert.equal(otherDoc4.isSaved(), false);
         done();
-      }).error(done);
+      }).catch(done);
     });
     it('hasAndBelongsToMany -- not primary keys - 2', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -1643,7 +1643,7 @@ describe('Advanced cases', function(){
         assert.equal(otherDoc3.isSaved(), true);
         assert.equal(otherDoc4.isSaved(), false);
         done();
-      }).error(done);
+      }).catch(done);
     });
 
     it('hasAndBelongsToMany -- not primary keys -- doing what should never be done - 1', function(done) {
@@ -1695,7 +1695,7 @@ describe('Advanced cases', function(){
             });
           });
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasAndBelongsToMany -- not primary keys -- doing what should never be done - 2', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -1747,7 +1747,7 @@ describe('Advanced cases', function(){
             });
           });
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasAndBelongsToMany -- not primary keys -- doing what should never be done - 3', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -1798,7 +1798,7 @@ describe('Advanced cases', function(){
             });
           });
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasAndBelongsToMany -- not primary keys -- doing what should never be done - 4', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -1856,7 +1856,7 @@ describe('Advanced cases', function(){
             });
           });
         });
-      }).error(done);
+      }).catch(done);
     });
   });
   describe('getJoin', function(){
@@ -1896,7 +1896,7 @@ describe('Advanced cases', function(){
           });
         });
 
-      }).error(done);
+      }).catch(done);
     });
     it('hasOne - belongsTo - non matching modelToGet', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -1931,7 +1931,7 @@ describe('Advanced cases', function(){
           });
         });
 
-      }).error(done);
+      }).catch(done);
     });
     it('hasOne - belongsTo - matching modelToGet', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -1966,7 +1966,7 @@ describe('Advanced cases', function(){
             done()
           });
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasMany - belongsTo -- matching modelToGet', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -2004,7 +2004,7 @@ describe('Advanced cases', function(){
             done()
           })
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasMany - belongsTo -- non matching modelToGet', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -2042,7 +2042,7 @@ describe('Advanced cases', function(){
             done()
           })
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasMany - belongsTo -- default, fetch everything', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -2081,7 +2081,7 @@ describe('Advanced cases', function(){
             done()
           })
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasAndBelongsToMany -- primary keys -- fetch everything by default', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -2121,7 +2121,7 @@ describe('Advanced cases', function(){
             })
           });
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasAndBelongsToMany -- primary keys -- matching modelToGet', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -2161,7 +2161,7 @@ describe('Advanced cases', function(){
             })
           });
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasAndBelongsToMany -- primary keys -- non matching modelToGet', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -2201,7 +2201,7 @@ describe('Advanced cases', function(){
             })
           });
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasAndBelongsToMany -- primary keys -- matching modelToGet with options', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -2254,7 +2254,7 @@ describe('Advanced cases', function(){
             })
           });
         });
-      }).error(done);
+      }).catch(done);
     });
   });
   describe('pair', function(){
@@ -2296,7 +2296,7 @@ describe('Advanced cases', function(){
       }).then(function(result) {
         assert.equal(result.links.length, 2);
         done();
-      }).error(done);
+      }).catch(done);
     });
 
     it('hasAndBelongsToMany -- pairs', function(done) {
@@ -2318,7 +2318,7 @@ describe('Advanced cases', function(){
       }).then(function(result) {
         assert.deepEqual(result.links[0], doc2);
         done();
-      }).error(done);
+      }).catch(done);
     });
 
     it('hasOne/belongsTo -- pairs', function(done) {
@@ -2339,7 +2339,7 @@ describe('Advanced cases', function(){
         assert.equal(sophia.isSaved(), true);
         assert.equal(sophia.id, michel.contactId);
         done();
-      }).error(done);
+      }).catch(done);
     });
   });
   describe('delete - hidden links behavior', function() {
@@ -2884,7 +2884,7 @@ describe('Advanced cases', function(){
       }).then(function(result) {
         return doc2.saveAll()
       }).then(function(result) {
-        Model.get(doc1.id).getJoin({links: { _apply: function(seq) {
+        return Model.get(doc1.id).getJoin({links: { _apply: function(seq) {
           return seq.orderBy('id')
         }}}).run().then(function(result) {
           assert.equal(result.id, doc1.id);
@@ -2901,7 +2901,7 @@ describe('Advanced cases', function(){
             done()
           })
         });
-      }).error(done);
+      }).catch(done);
     });
     it('hasAndBelongsToMany -- with keys only and a missing doc', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -2974,7 +2974,7 @@ describe('Advanced cases', function(){
         assert.equal(result.links[1].id, doc2.links[1]);
         assert.equal(result.links[2].id, doc2.links[2]);
         done()
-      }).error(done);
+      }).catch(done);
     });
     it('hasAndBelongsToMany -- Adding a new relation', function(done) {
       var Model = thinky.createModel(modelNames[0], {
@@ -3011,12 +3011,12 @@ describe('Advanced cases', function(){
         return result.saveAll({links: true})
       }).then(function(result) {
         return Model.get(doc1.id).getJoin({links: { _apply: function(seq) {
-          return seq.orderBy('id')
+          return seq.orderBy('id');
         }}}).run()
       }).then(function(result) {
         assert.equal(result.id, doc1.id);
         assert.equal(result.links.length, 3);
-        done()
+        done();
       }).catch(done);
     });
     it('Regression #356 - 1', function(done) {

--- a/test/document.js
+++ b/test/document.js
@@ -58,7 +58,7 @@ describe('save', function() {
       doc.save().then(function(result) {
         assert.equal(doc.isSaved(), true);
         done();
-      }).error(done);
+      }).catch(done);
     });
     it('Save should fail if validate throws', function(done){
       var str = util.s8();
@@ -71,7 +71,7 @@ describe('save', function() {
       assert.equal(doc.isSaved(), false);
       doc.save().then(function(result) {
         done(new Error("Was expecting an error"));
-      }).error(function(error) {
+      }).catch(function(error) {
         done();
       });
     });
@@ -104,13 +104,13 @@ describe('save', function() {
         })
         doc2.save().then(function(r) {
           done(new Error("Expecting error"))
-        }).error(function (err) {
+        }).catch(function (err) {
           assert(err instanceof Errors.DuplicatePrimaryKey);
           assert(err.message.match(Errors.DUPLICATE_PRIMARY_KEY_REGEX));
           assert.equal(err.primaryKey, 'id');
           done();
         });
-      }).error(done);
+      }).catch(done);
     });
 
     it('setSaved should do the same', function(){
@@ -137,7 +137,7 @@ describe('save', function() {
       doc.save().then(function(result) {
         done();
 
-      }).error(done);
+      }).catch(done);
     });
     it('Save then the table is ready', function(done){
       var str = util.s8();
@@ -149,7 +149,7 @@ describe('save', function() {
       })
       doc.save().then(function(result) {
         done();
-      }).error(done);
+      }).catch(done);
     });
     it('Save the document should be updated on place', function(done){
       var str = util.s8();
@@ -165,7 +165,7 @@ describe('save', function() {
         assert.equal(doc.num, num);
         assert.notEqual(doc.id, undefined);
         done();
-      }).error(done);
+      }).catch(done);
     });
     it('Save should be able to update a doc', function(done){
       var str = util.s8();
@@ -185,7 +185,7 @@ describe('save', function() {
             done();
           });
         });
-      }).error(done);
+      }).catch(done);
     });
     it('Updating a document should keep a reference to the old value ', function(done){
       var str = util.s8();
@@ -207,7 +207,7 @@ describe('save', function() {
           });
           done();
         });
-      }).error(done);
+      }).catch(done);
     });
     it('Updating a document should validate it first (and in case of failure, it should not be persisted in the db)', function(done){
       var str = util.s8();
@@ -222,14 +222,14 @@ describe('save', function() {
         doc.str = 2
         doc.save().then(function(result) {
           done(new Error("Expecting an error"))
-        }).error(function() {
+        }).catch(function() {
           Model.get(doc.id).run().then(function(result) {
             // Make sure that the document was not updated
             assert.equal(result.str, str);
             done();
-          }).error(done);
+          }).catch(done);
         });
-      }).error(done);
+      }).catch(done);
     });
     it('Regression #117 - #118', function(done){
       var t = new Model({
@@ -239,7 +239,7 @@ describe('save', function() {
       t.save().then(function(result) {
         assert.equal(result.extra.nested, 1)
         done()
-      }).error(done)
+      }).catch(done)
     });
     it('Nesting undefined field', function(done){
       var t = new Model({
@@ -249,7 +249,7 @@ describe('save', function() {
       t.save().then(function(result) {
         assert.equal(result.extra.nested.foo, 1)
         done()
-      }).error(done)
+      }).catch(done)
     });
     it('Point - ReQL point', function(done){
       Model = thinky.createModel(modelNames[0], {
@@ -263,7 +263,7 @@ describe('save', function() {
       t.save().then(function(result) {
         assert.equal(result.point.$reql_type$, 'GEOMETRY');
         done()
-      }).error(done)
+      }).catch(done)
     });
   });
   describe("Replacement", function() {
@@ -285,7 +285,7 @@ describe('save', function() {
       }).then(function(result) {
         assert.equal(result.extra, undefined)
         done()
-      }).error(done).catch(done);
+      }).catch(done).catch(done);
     });
 
     it('Date as string should be coerced to ReQL dates', function(done){
@@ -307,7 +307,7 @@ describe('save', function() {
         assert.equal(Object.prototype.toString.call(result.date), "[object Object]");
         assert.equal(result.date.$reql_type$, "TIME");
         done()
-      }).error(done)
+      }).catch(done)
     });
     it('Date as string should be coerced to ReQL dates in array', function(done){
       var Model = thinky.createModel(modelNames[0], {
@@ -332,7 +332,7 @@ describe('save', function() {
         assert.equal(Object.prototype.toString.call(result.array[0].date), "[object Object]");
         assert.equal(result.array[0].date.$reql_type$, "TIME");
         done()
-      }).error(done)
+      }).catch(done)
     });
 
     it('Date as number should be coerced to ReQL dates', function(done){
@@ -353,7 +353,7 @@ describe('save', function() {
         assert.equal(Object.prototype.toString.call(result.date), "[object Object]");
         assert.equal(result.date.$reql_type$, "TIME");
         done()
-      }).error(done)
+      }).catch(done)
     });
     it('Points as array should be coerced to ReQL points', function(done){
       var Model = thinky.createModel(modelNames[0], {
@@ -371,8 +371,8 @@ describe('save', function() {
           assert.equal(t.loc.type, "Point")
           assert(Array.isArray(t.loc.coordinates))
           done()
-        }).error(done);
-      }).error(done)
+        }).catch(done);
+      }).catch(done)
     });
     it('Raw ReQL points should work', function(done){
       var Model = thinky.createModel(modelNames[0], {
@@ -393,8 +393,8 @@ describe('save', function() {
           assert.equal(t.loc.type, "Point")
           assert(Array.isArray(t.loc.coordinates))
           done()
-        }).error(done);
-      }).error(done)
+        }).catch(done);
+      }).catch(done)
     });
 
     it('Points as objects should be coerced to ReQL points', function(done){
@@ -413,7 +413,7 @@ describe('save', function() {
         assert.equal(t.loc.$reql_type$, "GEOMETRY")
         assert(Array.isArray(t.loc.coordinates))
         done()
-      }).error(done)
+      }).catch(done)
     });
     it('Points as geojson should be coerced to ReQL points', function(done){
       var Model = thinky.createModel(modelNames[0], {
@@ -431,7 +431,7 @@ describe('save', function() {
         assert.equal(t.loc.$reql_type$, "GEOMETRY")
         assert(Array.isArray(t.loc.coordinates))
         done()
-      }).error(done)
+      }).catch(done)
     });
     it('Number as string should be coerced to number', function(done){
       var Model = thinky.createModel(modelNames[0], {
@@ -449,7 +449,7 @@ describe('save', function() {
         assert.equal(typeof t.number, "number")
         assert.equal(t.number, 123456)
         done()
-      }).error(done)
+      }).catch(done)
     });
   });
   describe("Joins - hasOne", function() {
@@ -487,7 +487,7 @@ describe('save', function() {
         assert.equal(doc.str, docValues.str);
         assert.equal(doc.num, docValues.num);
         done();
-      }).error(done);
+      }).catch(done);
     });
     it('new should create instances of Document for joined documents too', function() {
       var docValues = {str: util.s8(), num: util.random(), otherDoc: {str: util.s8(), num: util.random()}}
@@ -505,7 +505,7 @@ describe('save', function() {
       doc.save().then(function(doc) {
         assert.strictEqual(doc.otherDoc, otherDoc)
         done();
-      }).error(done);
+      }).catch(done);
     })
     it('saveAll should save everything', function(done) {
       var docValues = {str: util.s8(), num: util.random()}
@@ -524,7 +524,7 @@ describe('save', function() {
         assert.strictEqual(doc.otherDoc, otherDoc)
         assert.strictEqual(doc.otherDoc.foreignKey, doc.id)
         done();
-      }).error(done);
+      }).catch(done);
     })
     it('save should not remove the foreign key', function(done) {
       var docValues = {str: util.s8(), num: util.random()}
@@ -541,7 +541,7 @@ describe('save', function() {
       }).then(function(result) {
         assert.equal(result.foreignKey, doc.id);
         done();
-      }).error(done);
+      }).catch(done);
     })
   });
   describe("Joins - belongsTo", function() {
@@ -577,7 +577,7 @@ describe('save', function() {
         assert.equal(doc.str, docValues.str);
         assert.equal(doc.num, docValues.num);
         done();
-      }).error(done);
+      }).catch(done);
     })
     it('save should not change the joined document', function(done) {
       var docValues = {str: util.s8(), num: util.random()}
@@ -589,7 +589,7 @@ describe('save', function() {
       doc.save().then(function(doc) {
         assert.strictEqual(doc.otherDoc, otherDoc)
         done();
-      }).error(done);
+      }).catch(done);
     })
     it('saveAll should save everything', function(done) {
       var docValues = {str: util.s8(), num: util.random()}
@@ -608,7 +608,7 @@ describe('save', function() {
         assert.strictEqual(doc.otherDoc, otherDoc)
         assert.strictEqual(doc.foreignKey, doc.otherDoc.id)
         done();
-      }).error(done);
+      }).catch(done);
     })
     it('saveAll should save a referene to this in the belongsTo doc', function(done) {
       var docValues = {str: util.s8(), num: util.random()}
@@ -620,7 +620,7 @@ describe('save', function() {
       doc.saveAll().then(function(doc2) {
         assert.equal(doc.otherDoc.__proto__._parents._belongsTo[Model.getTableName()][0].doc, doc);
         done();
-      }).error(done);
+      }).catch(done);
     })
     it('saveAll should delete a reference of belongsTo if the document was removed', function(done) {
       var docValues = {str: util.s8(), num: util.random()}
@@ -640,7 +640,7 @@ describe('save', function() {
 
           done();
         })
-      }).error(done);
+      }).catch(done);
     })
     it('saveAll should delete a reference of belongsTo only if the document was first retrieved', function(done) {
       var docValues = {str: util.s8(), num: util.random()}
@@ -666,7 +666,7 @@ describe('save', function() {
             });
           });
         });
-      }).error(done);
+      }).catch(done);
     });
     it('save should not remove the foreign key', function(done) {
       var docValues = {str: util.s8(), num: util.random()}
@@ -683,7 +683,7 @@ describe('save', function() {
       }).then(function(result) {
         assert.equal(result.foreignKey, otherDoc.id);
         done();
-      }).error(done);
+      }).catch(done);
     })
 
   });
@@ -725,7 +725,7 @@ describe('save', function() {
         assert.equal(doc.str, docValues.str);
         assert.equal(doc.num, docValues.num);
         done();
-      }).error(done);
+      }).catch(done);
     })
     it('save should not change the joined document', function(done) {
       var docValues = {str: util.s8(), num: util.random()}
@@ -736,7 +736,7 @@ describe('save', function() {
       doc.save().then(function(doc) {
         assert.strictEqual(doc.otherDocs, otherDocs)
         done();
-      }).error(done);
+      }).catch(done);
     })
     it('saveAll should save everything', function(done) {
       var docValues = {str: util.s8(), num: util.random()}
@@ -758,7 +758,7 @@ describe('save', function() {
           assert.strictEqual(doc.otherDocs[i].foreignKey, doc.id)
         }
         done();
-      }).error(done);
+      }).catch(done);
     })
     it('saveAll should not throw if the joined documents are missing', function(done) {
       var docValues = {str: util.s8(), num: util.random()}
@@ -766,7 +766,7 @@ describe('save', function() {
 
       doc.saveAll().then(function(doc) {
         done();
-      }).error(done);
+      }).catch(done);
     })
 
   });
@@ -805,7 +805,7 @@ describe('save', function() {
         assert.equal(doc.str, docValues.str);
         assert.equal(doc.num, docValues.num);
         done();
-      }).error(done);
+      }).catch(done);
     })
     it('save should not change the joined document', function(done) {
       var docValues = {str: util.s8(), num: util.random()}
@@ -820,7 +820,7 @@ describe('save', function() {
       doc.save().then(function(doc) {
         assert.strictEqual(doc.otherDocs, otherDocs)
         done();
-      }).error(done);
+      }).catch(done);
     })
     it('saveAll should save everything', function(done) {
       var docValues = {str: util.s8(), num: util.random()}
@@ -858,7 +858,7 @@ describe('save', function() {
           done();
         })
 
-      }).error(done);
+      }).catch(done);
     })
     it('saveAll should create new links with the good id', function(done) {
       var docValues = {str: util.s8(), num: util.random()}
@@ -904,8 +904,8 @@ describe('save', function() {
           assert.equal(total, 3);
 
           done();
-        }).error(done);
-      }).error(done);
+        }).catch(done);
+      }).catch(done);
     })
     it('saveAll should create new links with the secondary value', function(done) {
       var docValues = {str: util.s8(), num: util.random()}
@@ -950,10 +950,10 @@ describe('save', function() {
 
           assert.equal(total, 3);
           done();
-        }).error(done);
+        }).catch(done);
 
 
-      }).error(done);
+      }).catch(done);
     })
     it('saveAll should delete links if they are missing', function(done) {
       var linkName;
@@ -981,7 +981,7 @@ describe('save', function() {
             done();
           });
         });
-      }).error(done);
+      }).catch(done);
     })
     it('Keep the same reference', function(done) {
       var otherDoc = new OtherModel({str: util.s8(), num: util.random()});
@@ -1028,8 +1028,8 @@ describe('save', function() {
           assert.equal(total, 3);
 
           done();
-        }).error(done);
-      }).error(done);
+        }).catch(done);
+      }).catch(done);
     })
 
   });
@@ -1076,7 +1076,7 @@ describe('save', function() {
             done();
           });
         });
-      }).error(done);
+      }).catch(done);
 
     })
   });
@@ -1127,7 +1127,7 @@ describe('save', function() {
 
           });
         });
-      }).error(done);
+      }).catch(done);
 
     })
   });
@@ -1172,7 +1172,7 @@ describe('save', function() {
             })
           });
         });
-      }).error(done);
+      }).catch(done);
 
     })
   });
@@ -1225,10 +1225,10 @@ describe('save', function() {
             Model.get(doc.id).getJoin().run().then(function(result) {
               assert.equal(result.otherDocs.length, 2);
               done();
-            }).error(done);
-          }).error(done);
-        }).error(done);
-      }).error(done);
+            }).catch(done);
+          }).catch(done);
+        }).catch(done);
+      }).catch(done);
     })
   });
   describe('modelToSave', function() {
@@ -1298,7 +1298,7 @@ describe('save', function() {
         assert.equal(doc52.isSaved(), false);
         assert.equal(doc6.isSaved(), false);
         done();
-      }).error(done);
+      }).catch(done);
     });
     it('saveAll should save everything', function(done) {
       var doc1 = new Model1({})
@@ -1325,7 +1325,7 @@ describe('save', function() {
         assert.equal(doc52.isSaved(), true);
         assert.equal(doc6.isSaved(), true);
         done();
-      }).error(done);
+      }).catch(done);
     });
     it('saveAll should be limited by modelToSave - 1', function(done) {
       var doc1 = new Model1({})
@@ -1352,7 +1352,7 @@ describe('save', function() {
         assert.equal(doc52.isSaved(), false);
         assert.equal(doc6.isSaved(), false);
         done();
-      }).error(done);
+      }).catch(done);
     });
     it('saveAll should be limited by modelToSave - 2', function(done) {
       var doc1 = new Model1({})
@@ -1379,7 +1379,7 @@ describe('save', function() {
         assert.equal(doc52.isSaved(), false);
         assert.equal(doc6.isSaved(), true);
         done();
-      }).error(done);
+      }).catch(done);
     });
     it('saveAll should be limited by modelToSave - 3', function(done) {
       var doc1 = new Model1({})
@@ -1406,7 +1406,7 @@ describe('save', function() {
         assert.equal(doc52.isSaved(), false);
         assert.equal(doc6.isSaved(), false);
         done();
-      }).error(done);
+      }).catch(done);
     });
     it('saveAll should be limited by modelToSave - 4', function(done) {
       var doc1 = new Model1({})
@@ -1433,7 +1433,7 @@ describe('save', function() {
         assert.equal(doc52.isSaved(), true);
         assert.equal(doc6.isSaved(), false);
         done();
-      }).error(done);
+      }).catch(done);
     });
   })
   describe('validate', function() {
@@ -1443,7 +1443,7 @@ describe('save', function() {
       var doc = new Model({id: "notADate"});
       doc.save().then(function() {
         done(new Error("Was expecting an error"));
-      }).error(function(error) {
+      }).catch(function(error) {
         assert.equal(error.message, 'Value for [id] must be a date or a valid string or null.')
         done();
       });
@@ -1453,7 +1453,7 @@ describe('save', function() {
       var doc = new Model({id: "notADate"});
       doc.save().then(function() {
         done(new Error("Was expecting an error"));
-      }).error(function(error) {
+      }).catch(function(error) {
         assert(error instanceof Errors.ValidationError)
         done();
       });
@@ -1485,7 +1485,7 @@ describe('delete', function() {
         assert.equal(typeof doc.id, 'string');
         assert.equal(doc.isSaved(), true);
         done();
-      }).error(done);
+      }).catch(done);
     });
     it('should delete the document', function(done) {
       doc.delete().then(function() {
@@ -1493,7 +1493,7 @@ describe('delete', function() {
           assert.equal(result.length, 0);
           done();
         });
-      }).error(done);
+      }).catch(done);
     });
     it('should work with a callback', function(done) {
       doc.delete(function() {
@@ -1512,8 +1512,8 @@ describe('delete', function() {
             assert.equal(doc.isSaved(), false);
             done();
           });
-        }).error(done);
-      }).error(done);
+        }).catch(done);
+      }).catch(done);
     });
   });
   describe('hasOne', function() {
@@ -1555,10 +1555,10 @@ describe('delete', function() {
               assert.equal(result.length, 1);
               assert.deepEqual(result[0], otherDoc);
               done();
-            }).error(done);
+            }).catch(done);
 
           });
-        }).error(done);
+        }).catch(done);
 
       })
     });
@@ -1575,9 +1575,9 @@ describe('delete', function() {
         doc.deleteAll().then(function() {
           assert.equal(doc.isSaved(), false);
           assert.equal(otherDoc.isSaved(), false);
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
-            OtherModel.get(otherDoc.id).run().error(function(error) {
+            OtherModel.get(otherDoc.id).run().catch(function(error) {
               assert(error instanceof Errors.DocumentNotFound);
               done();
             });
@@ -1599,9 +1599,9 @@ describe('delete', function() {
         doc.deleteAll({otherDoc: true}).then(function() {
           assert.equal(doc.isSaved(), false);
           assert.equal(otherDoc.isSaved(), false);
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
-            OtherModel.get(otherDoc.id).run().error(function(error) {
+            OtherModel.get(otherDoc.id).run().catch(function(error) {
               assert(error instanceof Errors.DocumentNotFound);
               done();
             });
@@ -1628,9 +1628,9 @@ describe('delete', function() {
             OtherModel.get(otherDoc.id).run().then(function(result) {
               assert.deepEqual(result, otherDoc);
               done();
-            }).error(done);
+            }).catch(done);
           });
-        }).error(done);
+        }).catch(done);
       })
     });
 
@@ -1670,7 +1670,7 @@ describe('delete', function() {
         var otherDocCopy = util.deepCopy(doc.otherDoc);
 
         doc.delete().then(function() {
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
 
             OtherModel.get(otherDoc.id).run().then(function(result) {
@@ -1700,10 +1700,10 @@ describe('delete', function() {
           assert.strictEqual(doc, result);
           assert.equal(doc.otherDoc, undefined);
           assert.equal(otherDoc.isSaved(), false);
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
 
-            OtherModel.get(otherDoc.id).run().error(function(error) {
+            OtherModel.get(otherDoc.id).run().catch(function(error) {
               assert(error instanceof Errors.DocumentNotFound);
               done();
             });
@@ -1726,10 +1726,10 @@ describe('delete', function() {
           assert.equal(doc.isSaved(), false);
           assert.equal(otherDoc.isSaved(), false);
           assert.strictEqual(doc, result);
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
 
-            OtherModel.get(otherDoc.id).run().error(function(error) {
+            OtherModel.get(otherDoc.id).run().catch(function(error) {
               assert(error instanceof Errors.DocumentNotFound);
               done();
             });
@@ -1751,7 +1751,7 @@ describe('delete', function() {
         var otherDocCopy = util.deepCopy(doc.otherDoc);
 
         doc.deleteAll({foo: true}).then(function() {
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
 
             OtherModel.get(otherDoc.id).run().then(function(result) {
@@ -1795,7 +1795,7 @@ describe('delete', function() {
         assert.equal(doc.isSaved(), true);
 
         doc.delete().then(function() {
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
             assert.equal(doc.isSaved(), false);
             for(var i=0; i<otherDocs.length; i++) {
@@ -1822,7 +1822,7 @@ describe('delete', function() {
         assert.equal(doc.isSaved(), true);
 
         doc.deleteAll({foo: true}).then(function() {
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
             assert.equal(doc.isSaved(), false);
             assert.equal(doc.isSaved(), false);
@@ -1835,10 +1835,10 @@ describe('delete', function() {
               assert.equal(result.length, 3);
               assert.deepEqual(util.sortById(result), util.sortById(otherDocs));
               done();
-            }).error(done);
+            }).catch(done);
 
           });
-        }).error(done);
+        }).catch(done);
 
       })
     });
@@ -1853,7 +1853,7 @@ describe('delete', function() {
 
         doc.deleteAll().then(function(result) {
           assert.strictEqual(result, doc);
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
             assert.equal(doc.isSaved(), false);
             for(var i=0; i<otherDocs.length; i++) {
@@ -1881,7 +1881,7 @@ describe('delete', function() {
 
         doc.deleteAll({otherDocs: true}).then(function(result) {
           assert.strictEqual(result, doc);
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
             assert.equal(doc.isSaved(), false);
             for(var i=0; i<otherDocs.length; i++) {
@@ -1931,7 +1931,7 @@ describe('delete', function() {
           for(var i=0; i<otherDocs.length; i++) {
             assert.equal(doc.otherDocs[i].isSaved(), true)
           }
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
 
             OtherModel.getAll(otherDocs[0].id, otherDocs[1].id, otherDocs[2].id).run().then(function(result) {
@@ -1958,7 +1958,7 @@ describe('delete', function() {
           for(var i=0; i<otherDocs.length; i++) {
             assert.equal(doc.otherDocs[i].isSaved(), true)
           }
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
 
             OtherModel.getAll(otherDocs[0].id, otherDocs[1].id, otherDocs[2].id).run().then(function(result) {
@@ -1967,11 +1967,11 @@ describe('delete', function() {
               r.table(Model._joins.otherDocs.link).run().then(function(result) {
                 assert.equal(result.length, 0);
                 done();
-              }).error(done);
-            }).error(done);
+              }).catch(done);
+            }).catch(done);
 
           });
-        }).error(done);
+        }).catch(done);
 
       })
     });
@@ -1987,7 +1987,7 @@ describe('delete', function() {
           for(var i=0; i<otherDocs.length; i++) {
             assert.equal(otherDocs[i].isSaved(), false)
           }
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
 
             OtherModel.getAll(otherDocs[0].id, otherDocs[1].id, otherDocs[2].id).run().then(function(result) {
@@ -1996,11 +1996,11 @@ describe('delete', function() {
               r.table(Model._joins.otherDocs.link).run().then(function(result) {
                 assert.equal(result.length, 0);
                 done();
-              }).error(done);
-            }).error(done);
+              }).catch(done);
+            }).catch(done);
 
           });
-        }).error(done);
+        }).catch(done);
 
       })
     });
@@ -2016,7 +2016,7 @@ describe('delete', function() {
           for(var i=0; i<otherDocs.length; i++) {
             assert.equal(otherDocs[i].isSaved(), false)
           }
-          Model.get(doc.id).run().error(function(error) {
+          Model.get(doc.id).run().catch(function(error) {
             assert(error instanceof Errors.DocumentNotFound);
 
             OtherModel.getAll(otherDocs[0].id, otherDocs[1].id, otherDocs[2].id).run().then(function(result) {
@@ -2025,11 +2025,11 @@ describe('delete', function() {
               r.table(Model._joins.otherDocs.link).run().then(function(result) {
                 assert.equal(result.length, 0);
                 done();
-              }).error(done);
-            }).error(done);
+              }).catch(done);
+            }).catch(done);
 
           });
-        }).error(done);
+        }).catch(done);
 
       })
     });
@@ -2113,7 +2113,7 @@ describe('delete', function() {
 
           done();
         });
-      }).error(done);
+      }).catch(done);
     });
     it('deleteAll should follow modelToDelete if provided - 1', function(done) {
       var doc1 = new Model1({})
@@ -2150,7 +2150,7 @@ describe('delete', function() {
           assert.equal(doc6.isSaved(), true);
           done();
         });
-      }).error(done);
+      }).catch(done);
     });
     it('deleteAll should follow modelToDelete if provided - 2', function(done) {
       var doc1 = new Model1({})
@@ -2188,7 +2188,7 @@ describe('delete', function() {
 
           done();
         });
-      }).error(done);
+      }).catch(done);
     });
     it('deleteAll should follow modelToDelete if provided - 3', function(done) {
       var doc1 = new Model1({})
@@ -2226,7 +2226,7 @@ describe('delete', function() {
 
           done();
         });
-      }).error(done);
+      }).catch(done);
     });
   });
 });
@@ -2268,7 +2268,7 @@ describe('purge', function() {
           });
         });
       });
-    }).error(done);
+    }).catch(done);
   });
   it('should work with a callback', function(done) {
     var Model = thinky.createModel(modelNames[0], {
@@ -2305,7 +2305,7 @@ describe('purge', function() {
           });
         });
       });
-    }).error(done);
+    }).catch(done);
   });
   it('belongsTo -- purge should remove itself', function(done) {
     var Model = thinky.createModel(modelNames[0], {
@@ -2335,7 +2335,7 @@ describe('purge', function() {
           });
         });
       });
-    }).error(done);
+    }).catch(done);
   });
   it('belongsTo not called on its own model -- purge should remove itself + clean the other docs', function(done) {
     var Model = thinky.createModel(modelNames[0], {
@@ -2368,7 +2368,7 @@ describe('purge', function() {
           });
         });
       });
-    }).error(done);
+    }).catch(done);
   });
 
   it('hasMany -- purge should remove itself', function(done) {
@@ -2403,7 +2403,7 @@ describe('purge', function() {
           })
         });
       });
-    }).error(done);
+    }).catch(done);
   });
   it('hasAndBelongsToMany -- pk -- purge should clean the database', function(done) {
     var Model = thinky.createModel(modelNames[0], {
@@ -2436,7 +2436,7 @@ describe('purge', function() {
           });
         });
       });
-    }).error(done);;
+    }).catch(done);;
   });
   it('hasAndBelongsToMany not called on this model -- pk -- purge should clean the database', function(done) {
     var Model = thinky.createModel(modelNames[0], {
@@ -2470,7 +2470,7 @@ describe('purge', function() {
           });
         });
       });
-    }).error(done);
+    }).catch(done);
   });
   it('hasAndBelongsToMany -- not pk -- purge should clean the database', function(done) {
     var Model = thinky.createModel(modelNames[0], {
@@ -2506,7 +2506,7 @@ describe('purge', function() {
           });
         });
       });
-    }).error(done);
+    }).catch(done);
   });
   it('hasAndBelongsToMany not called on this model -- not pk -- purge should clean the database', function(done) {
     var Model = thinky.createModel(modelNames[0], {
@@ -2541,7 +2541,7 @@ describe('purge', function() {
           });
         });
       });
-    }).error(done);
+    }).catch(done);
   });
 });
 describe('date', function() {
@@ -2560,7 +2560,7 @@ describe('date', function() {
         assert.deepEqual(result.date, doc.date);
         done();
       });
-    }).error(done);;
+    }).catch(done);;
   });
 });
 
@@ -2580,7 +2580,7 @@ describe('default should be saved', function() {
     }).then(function(result) {
       assert.equal(result.num, 2)
       done();
-    }).error(done).catch(done);
+    }).catch(done).catch(done);
   });
   it('when generated on save', function(done) {
     var Model = thinky.createModel(modelNames[0], {
@@ -2596,7 +2596,7 @@ describe('default should be saved', function() {
     }).then(function(result) {
       assert.equal(result.num, 2)
       done();
-    }).error(done).catch(done);
+    }).catch(done).catch(done);
   });
 });
 
@@ -2709,7 +2709,7 @@ describe('hooks', function() {
     var doc = new Model({id: "foobar"}).then(function() {
       assert.equal(doc.id, doc.title)
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('init post async - error', function(done) {
     var Model = thinky.createModel(modelNames[0], {id: String, title: String});
@@ -2723,7 +2723,7 @@ describe('hooks', function() {
 
     var doc = new Model({id: "foobar"}).then(function() {
       done(new Error("Expecting error"));
-    }).error(function(err) {
+    }).catch(function(err) {
       assert.equal(err.message, "Async error thrown by a hook");
       done();
     });
@@ -2742,7 +2742,7 @@ describe('hooks', function() {
     var doc = new Model({id: "foobar"}).then(function() {
       assert.equal(doc.id, doc.title)
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('validate oncreate + init async', function(done) {
     var Model = thinky.createModel(modelNames[0], {id: String, title: String}, {validate: 'oncreate'});
@@ -2765,7 +2765,7 @@ describe('hooks', function() {
       assert.equal(doc.id, doc.title)
       assert.equal(doc.id, doc.title2)
       done();
-    }).error(done);
+    }).catch(done);
   });
 
   it('validate post sync', function() {
@@ -2807,7 +2807,7 @@ describe('hooks', function() {
     doc.validate().then(function() {
       assert.equal(doc.id, doc.title)
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('init post async - error', function(done) {
     var Model = thinky.createModel(modelNames[0], {id: String, title: String});
@@ -2822,7 +2822,7 @@ describe('hooks', function() {
     var doc = new Model({id: "foobar"});
     doc.validate().then(function() {
       done(new Error("Expecting error"));
-    }).error(function(err) {
+    }).catch(function(err) {
       assert.equal(err.message, "Async error thrown by a hook");
       done();
     });
@@ -2841,7 +2841,7 @@ describe('hooks', function() {
     doc.validateAll().then(function() {
       assert.equal(doc.id, doc.title)
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('init validateAll async joins', function(done) {
     var Model = thinky.createModel(modelNames[0], {id: String, title: String});
@@ -2863,7 +2863,7 @@ describe('hooks', function() {
     doc.validateAll().then(function() {
       assert.equal(otherDoc.id, otherDoc.title)
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('validate on save', function(done) {
     var Model = thinky.createModel(modelNames[0], {id: String, title: String});
@@ -2881,7 +2881,7 @@ describe('hooks', function() {
       assert.strictEqual(result, doc)
       assert.equal(result.id, result.title)
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('validate on retrieve - error on validate', function(done) {
     var Model = thinky.createModel(modelNames[0], {id: String, title: String});
@@ -2898,12 +2898,12 @@ describe('hooks', function() {
       r.table(Model.getTableName()).insert({id: 1}).run().then(function(result) {
         Model.get(1).run().then(function(result) {
           done(new Error("Was expecting an error"))
-        }).error(function(err) {
+        }).catch(function(err) {
           assert.equal(err.message, "Value for [id] must be a string or null.");
           assert(err instanceof Errors.ValidationError);
           done();
         });
-      }).error(done);
+      }).catch(done);
     });
   });
   it('validate on retrieve - error on hook', function(done) {
@@ -2921,11 +2921,11 @@ describe('hooks', function() {
       r.table(Model.getTableName()).insert({id: 1}).run().then(function(result) {
         Model.get(1).run().then(function(result) {
           done(new Error("Was expecting an error"))
-        }).error(function(err) {
+        }).catch(function(err) {
           assert.equal(err.message, "I'm Hook, and I'm a vilain");
           done();
         });
-      }).error(done);
+      }).catch(done);
     });
   });
   it('save pre', function(done) {
@@ -2947,7 +2947,7 @@ describe('hooks', function() {
         assert.equal(result.id, result.title);
         done();
       });
-    }).error(done);
+    }).catch(done);
   });
   it('save pre - with error and callback', function(done) {
     var Model = thinky.createModel(modelNames[0], {id: String, title: String});
@@ -2983,7 +2983,7 @@ describe('hooks', function() {
         assert.equal(result.id, result.title);
         done();
       });
-    }).error(done);
+    }).catch(done);
   });
 
   it('save post', function(done) {
@@ -3005,7 +3005,7 @@ describe('hooks', function() {
         assert.equal(result.title, undefined);
         done();
       });
-    }).error(done);
+    }).catch(done);
   });
   it('save pre join', function(done) {
     var Model = thinky.createModel(modelNames[0], {id: String, title: String});
@@ -3027,7 +3027,7 @@ describe('hooks', function() {
     doc.saveAll().then(function(result) {
       assert.equal(otherDoc.id, otherDoc.title)
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('save pre join', function(done) {
     var Model = thinky.createModel(modelNames[0], {id: String, title: String});
@@ -3049,7 +3049,7 @@ describe('hooks', function() {
     doc.saveAll().then(function(result) {
       assert.equal(otherDoc.id, otherDoc.title)
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('delete pre', function(done) {
     var Model = thinky.createModel(modelNames[0], {id: String, title: String});
@@ -3070,8 +3070,8 @@ describe('hooks', function() {
         assert.strictEqual(result, doc)
         assert.equal(doc.id, doc.title);
         done();
-      }).error(done);
-    }).error(done);
+      }).catch(done);
+    }).catch(done);
   });
   it('delete post', function(done) {
     var Model = thinky.createModel(modelNames[0], {id: String, title: String});
@@ -3092,8 +3092,8 @@ describe('hooks', function() {
         assert.strictEqual(result, doc)
         assert.equal(doc.id, doc.title);
         done();
-      }).error(done);
-    }).error(done);
+      }).catch(done);
+    }).catch(done);
   });
   it('hook for retrieve', function(done) {
     var Model = thinky.createModel(modelNames[0], {id: String, title: String});
@@ -3112,8 +3112,8 @@ describe('hooks', function() {
         Model.get(id).run().then(function(result) {
           assert.equal(result.title, result.id);
           done();
-        }).error(done);
-      }).error(done);
+        }).catch(done);
+      }).catch(done);
     });
   });
 });

--- a/test/feed.js
+++ b/test/feed.js
@@ -49,10 +49,10 @@ describe('Feeds', function() {
       assert.equal(feed.toString(), '[object Feed]')
       feed.close();
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('should implement each', function(done){
-    var data = [{}, {}, {}]
+    var data = [{}, {}, {}];
     Model.changes().run().then(function(feed) {
       var count = 0;
       feed.each(function(err, doc) {
@@ -64,12 +64,12 @@ describe('Feeds', function() {
         if (count === data.length) {
           feed.close().then(function() {
             done();
-          }).error(done);
+          }).catch(done);
         }
       })
-      //Model.insert(data).execute().error(done);
-      Model.save(data).error(done);
-    }).error(done);
+      //Model.insert(data).execute().catch(done);
+      return Model.save(data).catch(() => console.log('FEJIOWEHFWEHUFHEWUIFHEWUIFHEUWIFH'));
+    }).catch(done);
   });
   it('should implement next', function(done){
     var data = [{}, {}, {}]
@@ -86,10 +86,10 @@ describe('Feeds', function() {
         return feed.close()
       }).then(function() {
         done();
-      }).error(done);
+      }).catch(done);
 
-      Model.save(data).error(done);
-    }).error(done);
+      return Model.save(data).catch(done);
+    }).catch(done);
   });
   it('should handle events', function(done){
     var data = [{}, {}, {}]
@@ -102,12 +102,12 @@ describe('Feeds', function() {
           feed.removeAllListeners();
           feed.close().then(function() {
             done();
-          }).error(done);
+          }).catch(done);
         }
       });
 
-      Model.save(data).error(done);
-    }).error(done);
+      return Model.save(data).catch(done);
+    }).catch(done);
   });
 });
 
@@ -125,14 +125,14 @@ describe('Atom feeds', function() {
     });
   });
 
-  it('get().changes() should work - and remove default(r.error)', function(done){
+  it('get().changes() should work - and remove default(r.catch)', function(done){
     Model.get(1).changes({includeInitial: true}).run().then(function(doc) {
       assert(doc)
       assert.deepEqual(doc, {});
       return doc.closeFeed();
     }).then(function() {
       done();
-    }).error(done);
+    }).catch(done);
   });
 
   it('change events should be emitted - insert', function(done){
@@ -145,31 +145,31 @@ describe('Atom feeds', function() {
         assert.deepEqual(doc, data);
         doc.closeFeed().then(function() {
           done();
-        }).error(done);
+        }).catch(done);
       });
       Model.save(data);
-    }).error(done);
+    }).catch(done);
   });
   it('change events should be emitted - update', function(done){
     var data = {id: 'buzz', str: 'bar', num: 3};
     Model.save(data).then(function() {
-      Model.get(data.id).changes({includeInitial: true}).run().then(function(doc) {
+      return Model.get(data.id).changes({includeInitial: true}).run().then(function(doc) {
         assert.deepEqual(doc, data);
         doc.on('change', function() {
           assert.deepEqual(doc.getOldValue(), data);
           assert.deepEqual(doc, {id: 'buzz', str: 'foo', num: 3});
           doc.closeFeed().then(function() {
             done();
-          }).error(done);
+          }).catch(done);
         });
-        Model.get(data.id).update({str: "foo"}).run().error(done);
-      }).error(done);
+        return Model.get(data.id).update({str: "foo"}).run().catch(done);
+      }).catch(done);
     })
   });
   it('change events should be emitted - delete', function(done){
     var data = {id: 'bar', str: 'bar', num: 3};
     Model.save(data).then(function() {
-      Model.get(data.id).changes({includeInitial: true}).run().then(function(doc) {
+      return Model.get(data.id).changes({includeInitial: true}).run().then(function(doc) {
         assert.deepEqual(doc, data);
         doc.on('change', function() {
           assert.deepEqual(doc.getOldValue(), data);
@@ -177,10 +177,10 @@ describe('Atom feeds', function() {
           assert.equal(doc.isSaved(), false)
           doc.closeFeed().then(function() {
             done();
-          }).error(done);
+          }).catch(done);
         });
-        Model.get(data.id).delete().run().error(done);
-      }).error(done);
+        return Model.get(data.id).delete().run().catch(done);
+      }).catch(done);
 
     })
   });
@@ -203,7 +203,7 @@ describe('Atom feeds', function() {
           assert.equal(doc.isSaved(), false)
           doc.closeFeed().then(function() {
             done();
-          }).error(done);
+          }).catch(done);
         }
         count++;
       });
@@ -211,8 +211,8 @@ describe('Atom feeds', function() {
         return Model.get(data.id).update({str: 'foo'}).run();
       }).then(function() {
         Model.get(data.id).delete().run();
-      }).error(done);
-    }).error(done);
+      }).catch(done);
+    }).catch(done);
   });
 });
 

--- a/test/model.js
+++ b/test/model.js
@@ -19,7 +19,7 @@ var cleanTables = function(done) {
   for(var name in modelNameSet) {
     promises.push(r.table(name).delete().run());
   }
-  Promise.settle(promises).error(function () {/*ignore*/}).finally(function() {
+  Promise.settle(promises).catch(function () {/*ignore*/}).finally(function() {
     // Add the links table
     for(var model in thinky.models) {
       modelNameSet[model] = true;
@@ -43,7 +43,7 @@ describe('createModel', function(){
       r.tableList().run().then(function(result) {
         assert.notEqual(result.indexOf(modelNames[0]), -1)
         done();
-      }).error(done)
+      }).catch(done)
     });
   });
   it('Create multiple models', function(done) {
@@ -61,7 +61,7 @@ describe('createModel', function(){
   });
   it('Check if the table was created', function(done){
     model = thinky.createModel("nonExistingTable", {id: String, name: String}, {init: false})
-    model.get(1).run().then(function() { done(new Error("Expecting error")) }).error(function(e) {
+    model.get(1).run().then(function() { done(new Error("Expecting error")) }).catch(function(e) {
       assert(e.message.match(/^Table `.*` does not exist in/));
       done();
     });
@@ -183,7 +183,7 @@ describe("Batch insert", function() {
     Model.save({id: "foo"}).then(function(result) {
       assert.deepEqual(result, {id: "foo"});
       done();
-    }).error(function(e) {
+    }).catch(function(e) {
       done(e);
     });
   });
@@ -203,7 +203,7 @@ describe("Batch insert", function() {
         assert(docs[i].isSaved());
       }
       done();
-    }).error(function(e) {
+    }).catch(function(e) {
       done(e);
     });
   });
@@ -212,7 +212,7 @@ describe("Batch insert", function() {
       id: String,
       num: Number
     });
-    Model.save([{id: 4}]).error(function(err) {
+    Model.save([{id: 4}]).catch(function(err) {
       assert.equal(err.message, "One of the documents is not valid. Original error:\nValue for [id] must be a string or null.");
       assert(err instanceof Errors.ValidationError);
       done();
@@ -232,7 +232,7 @@ describe("Batch insert", function() {
       }
       Model.save(docs).then(function() {
         done(new Error("Was expecting an error"));
-      }).error(function(e) {
+      }).catch(function(e) {
         assert(e.message.match(/An error occurred during the batch insert/));
         done();
       });
@@ -247,7 +247,7 @@ describe("Batch insert", function() {
       assert.equal(result.id, "foo");
       assert.equal(result.location.$reql_type$, "GEOMETRY");
       done();
-    }).error(function(e) {
+    }).catch(function(e) {
       done(e);
     });
   });
@@ -262,7 +262,7 @@ describe("Batch insert", function() {
     }).then(function(result) {
       assert.deepEqual(result, {id: "foo", bar: "buzz"});
       done();
-    }).error(function(e) {
+    }).catch(function(e) {
       done(e);
     });
   });
@@ -277,7 +277,7 @@ describe("Batch insert", function() {
     }).then(function(result) {
       assert.deepEqual(result, {id: "foo"});
       done();
-    }).error(function(e) {
+    }).catch(function(e) {
       done(e);
     });
   });
@@ -427,8 +427,8 @@ describe("Joins", function() {
       r.table(otherModel.getTableName()).indexList().run().then(function(result) {
         r.table(otherModel.getTableName()).indexWait(foreignKey).run().then(function() {
           done();
-        }).error(done);
-      }).error(done);
+        }).catch(done);
+      }).catch(done);
     })
   });
   it('BelongsTo should create an index on the other model', function(done) {
@@ -446,8 +446,8 @@ describe("Joins", function() {
       r.table(otherModel.getTableName()).indexList().run().then(function(result) {
         r.table(otherModel.getTableName()).indexWait('otherId').run().then(function() {
           done();
-        }).error(done);
-      }).error(done);
+        }).catch(done);
+      }).catch(done);
     })
   });
   it('hasMany should create an index on the other model', function(done) {
@@ -466,9 +466,9 @@ describe("Joins", function() {
       r.table(otherModel.getTableName()).indexList().run().then(function(result) {
         r.table(otherModel.getTableName()).indexWait(foreignKey).run().then(function() {
           done();
-        }).error(done);
+        }).catch(done);
 
-      }).error(done);
+      }).catch(done);
     })
   });
 
@@ -491,9 +491,9 @@ describe("Joins", function() {
       r.table(model.getTableName()).indexList().run().then(function(result) {
         r.table(model.getTableName()).indexWait("notid1").run().then(function() {
           done();
-        }).error(done);
+        }).catch(done);
 
-      }).error(done);
+      }).catch(done);
     })
   });
 
@@ -516,8 +516,8 @@ describe("Joins", function() {
       r.table(otherModel.getTableName()).indexList().run().then(function(result) {
         r.table(otherModel.getTableName()).indexWait("notid2").run().then(function() {
           done();
-        }).error(done);
-      }).error(done);
+        }).catch(done);
+      }).catch(done);
     })
   });
 
@@ -542,8 +542,8 @@ describe("Joins", function() {
       r.table(linkName).indexList().run().then(function(result) {
         r.table(otherModel.getTableName()).indexWait("notid2").run().then(function() {
           done();
-        }).error(done);
-      }).error(done);
+        }).catch(done);
+      }).catch(done);
     });
   });
   it('_apply is reserved ', function() {
@@ -756,7 +756,7 @@ describe('virtual', function(){
     }).then(function(result) {
       assert.equal(result.numVirtual, undefined);
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('Virtual fields should not be saved but still regenerated once retrieved', function(done) {
     var Model = thinky.createModel(modelNames[0], {
@@ -784,7 +784,7 @@ describe('virtual', function(){
       assert.equal(result.numVirtual, 3);
 
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('Virtual fields should not be saved but should be put back later (if no default)', function(done) {
     var Model = thinky.createModel(modelNames[0], {
@@ -806,7 +806,7 @@ describe('virtual', function(){
       assert.equal(result.numVirtual, undefined);
 
       done();
-    }).error(done).catch(done);
+    }).catch(done).catch(done);
   });
   it('Virtual fields should be genrated after other default values', function() {
     var Model = thinky.createModel(modelNames[0], {

--- a/test/query.js
+++ b/test/query.js
@@ -75,7 +75,7 @@ describe('Model queries', function() {
       }
 
       done()
-    }).error(done);
+    }).catch(done);
   });
 
   after(cleanTables);
@@ -83,7 +83,7 @@ describe('Model queries', function() {
   it('Model.run() should return', function(done){
     Model.run().then(function(result) {
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('Model.run() should take a callback', function(done){
     Model.run(function(err, result) {
@@ -100,7 +100,7 @@ describe('Model queries', function() {
       assert.equal(result.length, 3);
       assert.deepEqual(bag, newBag);
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('Model.run() should return instances of Document', function(done){
     Model.run().then(function(result) {
@@ -109,7 +109,7 @@ describe('Model queries', function() {
         assert(result[i] instanceof Document);
       }
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('Model.run() should return instances of the model', function(done){
     Model.run().then(function(result) {
@@ -119,12 +119,12 @@ describe('Model queries', function() {
         assert.deepEqual(result[i].constructor, Model);
       }
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('Model.add(1).run() should be able to error', function(done){
     Model.add(1).run().then(function(result) {
       done(new Error("The promise should not be resolved."))
-    }).error(function(error) {
+    }).catch(function(error) {
       assert(error.message.match(/^Expected type DATUM but found TABLE/));
       done();
     });
@@ -132,7 +132,7 @@ describe('Model queries', function() {
   it('Model.map(1).run should error', function(done){
     Model.map(function() { return 1 }).run().then(function(result) {
       done(new Error("The promise should not be resolved."))
-    }).error(function(error) {
+    }).catch(function(error) {
       assert.equal(error.message, "The results could not be converted to instances of `"+Model.getTableName()+"`\nDetailed error: Cannot build a new instance of `"+Model.getTableName()+"` without an object")
       done();
     });
@@ -141,19 +141,19 @@ describe('Model queries', function() {
     Model.get(data[0].id).run().then(function(result) {
       assert.deepEqual(data[0], result);
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('Model._get() should return null if no doc is found', function(done){
     Model._get('nonExistingId').execute().then(function(result) {
       assert.equal(result, null)
       done();
-    }).error(done);
+    }).catch(done);
   });
 
   it('Model.get().merge(..) should throw before calling merge', function(done){
     Model.get("NonExistingKey").merge({foo: "bar"}).run().then(function(result) {
       done(new Error("Was expecting an error"));
-    }).error(function(error) {
+    }).catch(function(error) {
       assert(error.message.match(Errors.DOCUMENT_NOT_FOUND_REGEX));
       done();
     });
@@ -164,7 +164,7 @@ describe('Model queries', function() {
       assert.deepEqual(result.__proto__.constructor, Model);
       assert.deepEqual(result.constructor, Model);
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('Model.group("foo").run should work -- without extra argument', function(done){
     Model.group("foo").run().then(function(result) {
@@ -176,7 +176,7 @@ describe('Model queries', function() {
         }
       }
       done()
-    }).error(function(error) {
+    }).catch(function(error) {
       done();
     });
   });
@@ -190,7 +190,7 @@ describe('Model queries', function() {
         }
       }
       done()
-    }).error(function(error) {
+    }).catch(function(error) {
       done();
     });
   });
@@ -199,7 +199,7 @@ describe('Model queries', function() {
       assert(result instanceof Document);
       assert(result.isSaved());
       done()
-    }).error(function(error) {
+    }).catch(function(error) {
       done();
     });
   });
@@ -213,7 +213,7 @@ describe('Model queries', function() {
         }
       }
       done()
-    }).error(function(error) {
+    }).catch(function(error) {
       done();
     });
   });
@@ -226,7 +226,7 @@ describe('Model queries', function() {
         }
       }
       done()
-    }).error(function(error) {
+    }).catch(function(error) {
       done();
     });
   });
@@ -250,27 +250,27 @@ describe('Model queries', function() {
       }
       done();
 
-    }).error(done);
+    }).catch(done);
   });
   it('Model.filter(false) should work', function(done){
     Model.filter(false).run().then(function(result) {
       assert.equal(result.length, 0);
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('Model.execute should not return instances of the model', function(done){
     Model.execute().then(function(result) {
       assert(!(result[0] instanceof Document));
       assert.equal(result.length, 3);
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('Model.execute should work with a callback', function(done){
     Model.execute(function(err, result) {
       assert(!(result[0] instanceof Document));
       assert.equal(result.length, 3);
       done();
-    }).error(done);
+    }).catch(done);
   });
 
   it('Model.map(1).execute should work', function(done){
@@ -278,12 +278,12 @@ describe('Model queries', function() {
       assert(!(result[0] instanceof Document));
       assert.equal(result.length, 3);
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('Model.add(1).execute() should be able to error', function(done){
     Model.add(1).execute().then(function(result) {
       done(new Error("The promise should not be resolved."))
-    }).error(function(error) {
+    }).catch(function(error) {
       assert(error.message.match(/^Expected type DATUM but found TABLE/));
       done();
     });
@@ -331,7 +331,7 @@ describe('getJoin', function(){
         assert(result.isSaved());
         assert(result.otherDoc.isSaved());
         done()
-      }).error(done);
+      }).catch(done);
     })
     it('should retrieve joined documents with sequence', function(done) {
       Model.filter({id: doc.id}).getJoin().run().then(function(result) {
@@ -339,7 +339,7 @@ describe('getJoin', function(){
         assert(result[0].isSaved());
         assert(result[0].otherDoc.isSaved());
         done()
-      }).error(done);
+      }).catch(done);
     })
   })
   describe("Joins - belongsTo", function() {
@@ -381,7 +381,7 @@ describe('getJoin', function(){
         assert(result.isSaved());
         assert(result.otherDoc.isSaved());
         done()
-      }).error(done);
+      }).catch(done);
     })
     it('should retrieve joined documents with sequence', function(done) {
       Model.filter({id: doc.id}).getJoin().run().then(function(result) {
@@ -389,7 +389,7 @@ describe('getJoin', function(){
         assert(result[0].isSaved());
         assert(result[0].otherDoc.isSaved());
         done()
-      }).error(done);
+      }).catch(done);
     })
   })
   describe("Joins - hasMany with allowExtra(false)", function() {
@@ -419,7 +419,7 @@ describe('getJoin', function(){
       doc.saveAll().then(function(doc) {
         util.sortById(doc.otherDocs);
         done();
-      }).error(done);
+      }).catch(done);
 
     });
 
@@ -435,7 +435,7 @@ describe('getJoin', function(){
           assert.equal(result.otherDocs[i].isSaved(), true);
         }
         done()
-      }).error(done);
+      }).catch(done);
     })
     it('should retrieve joined documents with sequence', function(done) {
       Model.filter({id: doc.id}).getJoin().run().then(function(result) {
@@ -448,7 +448,7 @@ describe('getJoin', function(){
         }
 
         done()
-      }).error(done);
+      }).catch(done);
     })
   })
   describe("Joins - hasMany with removeExtra()", function() {
@@ -478,7 +478,7 @@ describe('getJoin', function(){
       doc.saveAll().then(function(doc) {
         util.sortById(doc.otherDocs);
         done();
-      }).error(done);
+      }).catch(done);
 
     });
 
@@ -494,7 +494,7 @@ describe('getJoin', function(){
           assert.equal(result.otherDocs[i].isSaved(), true);
         }
         done()
-      }).error(done);
+      }).catch(done);
     })
     it('should retrieve joined documents with sequence', function(done) {
       Model.filter({id: doc.id}).getJoin().run().then(function(result) {
@@ -507,7 +507,7 @@ describe('getJoin', function(){
         }
 
         done()
-      }).error(done);
+      }).catch(done);
     })
   })
   describe("Joins - hasMany", function() {
@@ -537,7 +537,7 @@ describe('getJoin', function(){
       doc.saveAll().then(function(doc) {
         util.sortById(doc.otherDocs);
         done();
-      }).error(done);
+      }).catch(done);
 
     });
 
@@ -553,7 +553,7 @@ describe('getJoin', function(){
           assert.equal(result.otherDocs[i].isSaved(), true);
         }
         done()
-      }).error(done);
+      }).catch(done);
     })
     it('should retrieve joined documents with sequence', function(done) {
       Model.filter({id: doc.id}).getJoin().run().then(function(result) {
@@ -566,7 +566,7 @@ describe('getJoin', function(){
         }
 
         done()
-      }).error(done);
+      }).catch(done);
     })
   })
   describe("Joins - hasAndBelongsToMany", function() {
@@ -595,7 +595,7 @@ describe('getJoin', function(){
       doc.saveAll().then(function(doc) {
         util.sortById(doc.otherDocs);
         done();
-      }).error(done);
+      }).catch(done);
 
     });
 
@@ -611,7 +611,7 @@ describe('getJoin', function(){
           assert.equal(result.otherDocs[i].isSaved(), true);
         }
         done()
-      }).error(done);
+      }).catch(done);
     })
     it('should retrieve joined documents with sequence', function(done) {
       Model.filter({id: doc.id}).getJoin().run().then(function(result) {
@@ -624,7 +624,7 @@ describe('getJoin', function(){
         }
 
         done()
-      }).error(done);
+      }).catch(done);
     })
   })
   describe('options', function() {
@@ -683,7 +683,7 @@ describe('getJoin', function(){
           assert.equal(result.has.length, 5);
           done();
         });
-      }).error(done);
+      }).catch(done);
     });
     it('_apply should work with count (not coerce to arrays)', function(done) {
       var name = util.s8();
@@ -717,7 +717,7 @@ describe('getJoin', function(){
           assert.equal(result.has, 3);
           done();
         });
-      }).error(done);
+      }).catch(done);
     });
 
   });
@@ -748,8 +748,8 @@ describe('getJoin', function(){
         Model.get(doc.id).getJoin().run().then(function(result) {
           assert.equal(result.otherDoc, undefined);
           done();
-        }).error(done);
-      }).error(done);
+        }).catch(done);
+      }).catch(done);
     });
     it('belongsTo', function(done) {
       Model = thinky.createModel(modelNames[0], {
@@ -773,7 +773,7 @@ describe('getJoin', function(){
         Model.get(doc.id).getJoin().run().then(function(result) {
           assert.equal(result.otherDoc, undefined);
           done();
-        }).error(done);
+        }).catch(done);
       });
     });
     it('hasMany', function(done) {
@@ -797,7 +797,7 @@ describe('getJoin', function(){
         Model.get(doc.id).getJoin().run().then(function(result) {
           assert.equal(result.otherDocs, undefined);
           done();
-        }).error(done);
+        }).catch(done);
       });
     });
     it('hasAndBelongsToMany', function(done) {
@@ -821,8 +821,8 @@ describe('getJoin', function(){
         Model.get(doc.id).getJoin().run().then(function(result) {
           assert.equal(result.otherDocs, undefined);
           done();
-        }).error(done);
-      }).error(done);
+        }).catch(done);
+      }).catch(done);
 
     });
   });
@@ -1141,9 +1141,9 @@ describe('removeRelation', function(){
     doc.saveAll().then(function(doc) {
       return Model.get(doc.id).removeRelation('otherDoc').run()
     }).then(function(otherDocResults) {
-      assert.equal(otherDocResults.id, otherDoc.id); 
-      assert.equal(otherDocResults.str, otherDoc.str); 
-      assert.equal(otherDocResults.num, otherDoc.num); 
+      assert.equal(otherDocResults.id, otherDoc.id);
+      assert.equal(otherDocResults.str, otherDoc.str);
+      assert.equal(otherDocResults.num, otherDoc.num);
       return OtherModel.get(otherDoc.id).run()
     }).then(function(doc) {
       assert.equal(doc.foreignKey, undefined);
@@ -1178,9 +1178,9 @@ describe('removeRelation', function(){
       return Model.get(doc.id).removeRelation('otherDocs').run()
     }).then(function(otherDocResults) {
       assert.equal(otherDocResults.length, 1);
-      assert.equal(otherDocResults[0].id, otherDoc.id); 
-      assert.equal(otherDocResults[0].str, otherDoc.str); 
-      assert.equal(otherDocResults[0].num, otherDoc.num); 
+      assert.equal(otherDocResults[0].id, otherDoc.id);
+      assert.equal(otherDocResults[0].str, otherDoc.str);
+      assert.equal(otherDocResults[0].num, otherDoc.num);
 
       return OtherModel.get(otherDoc.id).run()
     }).then(function(doc) {
@@ -1218,9 +1218,9 @@ describe('removeRelation', function(){
       return Model.get(doc.id).removeRelation('otherDocs', {id: otherDoc2.id}).run()
     }).then(function(otherDocResults) {
       assert.equal(otherDocResults.length, 1);
-      assert.equal(otherDocResults[0].id, otherDoc2.id); 
-      assert.equal(otherDocResults[0].str, otherDoc2.str); 
-      assert.equal(otherDocResults[0].num, otherDoc2.num); 
+      assert.equal(otherDocResults[0].id, otherDoc2.id);
+      assert.equal(otherDocResults[0].str, otherDoc2.str);
+      assert.equal(otherDocResults[0].num, otherDoc2.num);
 
       return Model.get(doc.id).getJoin({otherDocs: true}).run()
     }).then(function(doc) {
@@ -1421,9 +1421,9 @@ describe('Query.run() should take options', function(){
           data.push(result);
 
           done()
-        }).error(done);
-      }).error(done);
-    }).error(done);
+        }).catch(done);
+      }).catch(done);
+    }).catch(done);
   });
 
   after(cleanTables);
@@ -1435,7 +1435,7 @@ describe('Query.run() should take options', function(){
     }).catch(Errors.DocumentNotFound, function(err) {
       assert(err.message.match(Errors.DOCUMENT_NOT_FOUND_REGEX));
       done();
-    }).error(function() {
+    }).catch(function() {
       done(new Error("Not the expected error"))
     });
   });
@@ -1443,7 +1443,7 @@ describe('Query.run() should take options', function(){
     var Errors = thinky.Errors;
     Model.get(0).run().then(function() {
       done(new Error("Was expecting an error"))
-    }).error(function(err) {
+    }).catch(function(err) {
       assert(err instanceof Errors.DocumentNotFound);
       assert(err.message.match(Errors.DOCUMENT_NOT_FOUND_REGEX));
       done();
@@ -1460,7 +1460,7 @@ describe('Query.run() should take options', function(){
         }
       }
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('Query.run({groupFormat: "raw"}) should be ignored', function(done){
     Model.group('num').run({groupFormat: "raw"}).then(function(result) {
@@ -1470,7 +1470,7 @@ describe('Query.run() should take options', function(){
         assert(result[i].reduction.length > 0)
       }
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('Query.execute({groupFormat: "raw"}) should not be ignored', function(done){
     Model.group('num').execute({groupFormat: "raw"}).then(function(result) {
@@ -1480,12 +1480,12 @@ describe('Query.run() should take options', function(){
         assert.equal(result.data[i].length, 2)
       }
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('Query.group("num").count().run() should not work', function(done){
     Model.group('num').count().run().then(function(result) {
       done(new Error("Should have thrown an error"))
-    }).error(function(err) {
+    }).catch(function(err) {
       done()
     });
   });
@@ -1494,14 +1494,14 @@ describe('Query.run() should take options', function(){
       assert.equal(result.length, 2);
       assert(result[0].reduction instanceof Document);
       done();
-    }).error(done);
+    }).catch(done);
   });
   it('Query.group("num").count().execute() should work', function(done){
     Model.group('num').count().execute().then(function(result) {
       assert.equal(result.length, 2);
       assert((result[0].reduction === 2 && result[0].group === 1) ||(result[0].reduction === 1 && result[0].group === 2))
       done()
-    }).error(done);
+    }).catch(done);
   });
 });
 
@@ -1578,7 +1578,7 @@ describe('error', function() {
     var r = thinky.r;
     var User = thinky.createModel(modelNames[0], {id: String}, {init: false});
 
-    User.filter(r.error('test')).error(function() {
+    User.filter(r.error('test')).catch(function() {
         done();
     });
   });
@@ -1589,7 +1589,7 @@ describe('error', function() {
     var r = thinky.r;
     var User = thinky.createModel(modelNames[0], {id: String}, {init: false});
 
-    var promise = User.filter(r.error('test')).error(function() {});
+    var promise = User.filter(r.error('test')).catch(function() {});
     assert(promise instanceof Promise, 'not a promise');
 
     promise.finally(function() {
@@ -1707,8 +1707,8 @@ describe('optimizer', function() {
         Model.once('ready', function() {
           done();
         })
-      }).error(done);
-    }).error(done);
+      }).catch(done);
+    }).catch(done);
   });
   it('orderBy should be able to use an index - thanks to ensureIndex', function() {
     var query = Model.orderBy('name1').toString();
@@ -1776,7 +1776,7 @@ describe('In place writes', function() {
       // We can force changes to be retrieved with returnChanges: 'always'
       assert.deepEqual(result, {id: doc.id, num: 1});
       done();
-    }).error(done);
+    }).catch(done);
   })
   it('Point write - post non valid - primary key is a string', function(done) {
     var Model = thinky.createModel(modelNames[0], {
@@ -1788,12 +1788,12 @@ describe('In place writes', function() {
       return Model.get(doc.id).update({num: r.expr("foo")}).run()
     }).then(function() {
       done(new Error("Was expecting an error"));
-    }).error(function(error) {
+    }).catch(function(error) {
       assert(error.message.match("The write failed, and the changes were reverted"));
       Model.get(doc.id).run().then(function(result) {
         assert.deepEqual(doc, result);
         done();
-      }).error(done);
+      }).catch(done);
     })
   })
   it('Point write - post non valid - primary key not a string', function(done) {
@@ -1806,12 +1806,12 @@ describe('In place writes', function() {
       return Model.get(doc.id).update({num: r.expr("foo")}).run()
     }).then(function() {
       done(new Error("Was expecting an error"));
-    }).error(function(error) {
+    }).catch(function(error) {
       assert(error.message.match("The write failed, and the changes were reverted"));
       Model.get(doc.id).run().then(function(result) {
         assert.deepEqual(doc, result);
         done();
-      }).error(done);
+      }).catch(done);
     })
   })
   it('Range write - valid', function(done) {
@@ -1832,7 +1832,7 @@ describe('In place writes', function() {
       assert.equal(result[0].num, 1);
       assert.equal(result[1].num, 1);
       done();
-    }).error(done);
+    }).catch(done);
   })
   it('Range write with one doc - valid', function(done) {
     var Model = thinky.createModel(modelNames[0], {
@@ -1847,7 +1847,7 @@ describe('In place writes', function() {
       assert.equal(result[0].id, docs[0].id);
       assert.equal(result[0].num, 1);
       done();
-    }).error(done);
+    }).catch(done);
   })
 
   it('Range write - post non valid - primary key is a string', function(done) {
@@ -1860,15 +1860,15 @@ describe('In place writes', function() {
       return Model.update({num: r.expr("foo")}).run()
     }).then(function() {
       done(new Error("Was expecting an error"));
-    }).error(function(error) {
+    }).catch(function(error) {
       assert(error.message.match("The write failed, and the changes were reverted"));
       Model.run().then(function(result) {
         result.sort(function(a, b) { return (a.num > b.num) ? 1 : -1; });
         assert.equal(result[0].num, 0);
         assert.equal(result[1].num, 1);
         done();
-      }).error(done);
-    }).error(done);
+      }).catch(done);
+    }).catch(done);
   })
   it('Range write - post non valid - primary key is not a string', function(done) {
     var Model = thinky.createModel(modelNames[0], {
@@ -1880,16 +1880,16 @@ describe('In place writes', function() {
       return Model.update({num: r.expr("foo")}).run()
     }).then(function() {
       done(new Error("Was expecting an error"));
-    }).error(function(error) {
+    }).catch(function(error) {
       assert(error.message.match("The write failed, and the changes were reverted"));
       Model.run().then(function(result) {
         result.sort(function(a, b) { return (a.num > b.num) ? 1 : -1; });
         assert.equal(result[0].num, 0);
         assert.equal(result[1].num, 1);
         done();
-      }).error(done);
+      }).catch(done);
 
-    }).error(done);
+    }).catch(done);
   })
   it('Point write - pre non valid', function(done) {
     var Model = thinky.createModel(modelNames[0], {
@@ -1901,12 +1901,12 @@ describe('In place writes', function() {
       return Model.get(doc.id).update({num: "foo"}).run()
     }).then(function() {
       done(new Error("Was expecting an error"));
-    }).error(function(error) {
+    }).catch(function(error) {
       assert(error.message.match(/^The partial value is not valid, so the write was not executed. The original error was:/));
       Model.get(doc.id).run().then(function(result) {
         assert.deepEqual(doc, result);
         done();
-      }).error(done);
+      }).catch(done);
     })
   })
   it('Point write on non existing doc', function(done) {
@@ -1914,7 +1914,7 @@ describe('In place writes', function() {
       id: String,
       num: Number
     });
-    Model.get('nonExistingId').update({foo: 'bar'}).run().error(function(error) {
+    Model.get('nonExistingId').update({foo: 'bar'}).run().catch(function(error) {
       assert(Errors.DOCUMENT_NOT_FOUND_REGEX.test(error.message));
       done();
     });
@@ -1944,7 +1944,7 @@ describe('In place writes', function() {
 
     it('handles Promises', function (done) {
       var Model = thinky.createModel(modelNames[0], {id: String});
-    
+
       var doc = new Model({id: util.s8(), num: 0});
       var bound = Model.get(doc.id).bindRun();
 
@@ -1961,7 +1961,7 @@ describe('In place writes', function() {
 
     it('handles node-style callbacks', function (done) {
       var Model = thinky.createModel(modelNames[0], {id: String});
-    
+
       var doc = new Model({id: util.s8(), num: 0});
       var bound = Model.get(doc.id).bindRun();
 
@@ -1982,7 +1982,7 @@ describe('In place writes', function() {
 
     it('handles Promises', function (done) {
       var Model = thinky.createModel(modelNames[0], {id: String});
-    
+
       var doc = new Model({id: util.s8(), num: 0});
       var bound = Model.get(doc.id).bindExecute();
 
@@ -1999,7 +1999,7 @@ describe('In place writes', function() {
 
     it('handles node-style callbacks', function (done) {
       var Model = thinky.createModel(modelNames[0], {id: String});
-    
+
       var doc = new Model({id: util.s8(), num: 0});
       var bound = Model.get(doc.id).bindExecute();
 
@@ -2015,5 +2015,5 @@ describe('In place writes', function() {
     });
 
   });
-  
+
 });


### PR DESCRIPTION
This migrates existing `2.10.2` Bluebird to latest `3.4.6`. As per discussion on #430 (now closed), this is a breaking change. I believe it really should be the way to go and deserves being released under a `3.0.0` tag.