### PR TITLE
Schemas Documentation Updates

### DIFF
--- a/documentation/schemas.md
+++ b/documentation/schemas.md
@@ -122,6 +122,7 @@ This is the only guarantee. A default value should not rely on another default v
 _Example_: Create a basic Model for a `user`.
 
 ```js
+var type = thinky.type;
 var User = thinky.createModel("User", {
     id: type.string(),
     name: type.string(),
@@ -143,6 +144,7 @@ The reason behind the validator field is that you can import modules that are go
 _Example_: Create a model with nested fields.
 
 ```js
+var type = thinky.type;
 var User = thinky.createModel("User", {
     id: type.string(),
     contact: {
@@ -156,6 +158,7 @@ var User = thinky.createModel("User", {
 Another way to do it is with:
 
 ```js
+var type = thinky.type;
 var User = thinky.createModel("User", {
     id: type.string(),
     contact: type.object().schema({
@@ -169,6 +172,7 @@ var User = thinky.createModel("User", {
 _Example_: Create a model where the field `scores` is an array of `Number`.
 
 ```js
+var type = thinky.type;
 var Game = thinky.createModel("Game", {
     id: type.string(),
     name: type.string(),
@@ -179,6 +183,7 @@ var Game = thinky.createModel("Game", {
 Another way to do it is with:
 
 ```js
+var type = thinky.type;
 var Game = thinky.createModel("Game", {
     id: type.string(),
     name: type.string(),
@@ -189,6 +194,7 @@ var Game = thinky.createModel("Game", {
 _Example_: Create a model where the field `game` is an array of objects with two fields &mdash; `score` and `winner`.
 
 ```js
+var type = thinky.type;
 var Game = thinky.createModel("Game", {
     id: type.string(),
     name: type.string(0,
@@ -202,6 +208,7 @@ var Game = thinky.createModel("Game", {
 You can also do the same with:
 
 ```js
+var type = thinky.type;
 var Game = thinky.createModel("Game", {
     id: type.string(),
     name: type.string(),
@@ -216,6 +223,7 @@ _Example_: Create a model for a post where the default value for `createdAt` is 
 current date if not specified.
 
 ```js
+var type = thinky.type;
 var Post = thinky.createModel("Post",{
     id: type.string(),
     title: type.string(),
@@ -228,6 +236,7 @@ _Example_: Create a model for a user where the nickname, if not defined, will be
 name.
 
 ```js
+var type = thinky.type;
 var Post = thinky.createModel("Post",{
     id: type.string(),
     firstname: type.string(),
@@ -242,6 +251,7 @@ _Example_: Create a model for a `post` where the field `title` must be a `String
 (where `null` will not be a valid value).
 
 ```js
+var type = thinky.type;
 var Post = thinky.createModel("Post",{
     id: type.string(),
     title: type.string().options({enforce_type: "strict"}),
@@ -254,6 +264,7 @@ _Example_: Create a model `User` and make sure that the field email is a valid e
 using [validator](https://github.com/chriso/validator.js)
 
 ```js
+var type = thinky.type;
 var validator = require('validator');
 
 var User = thinky.createModel("Users",{

--- a/documentation/schemas.md
+++ b/documentation/schemas.md
@@ -131,19 +131,6 @@ var User = thinky.createModel("User", {
 })
 ```
 
-Another way to do it is with `type`:
-
-```js
-var type = thinky.type;
-var User = thinky.createModel("User", {
-    id: type.string(),
-    name: type.string(),
-    email: type.string(),
-    age: type.number(),
-    birthdate: type.date()
-})
-```
-
 __Note__: About validator:
 
 The reason behind the validator field is that you can import modules that are good at validating data like
@@ -169,21 +156,6 @@ var User = thinky.createModel("User", {
 Another way to do it is with:
 
 ```js
-var type = thinky.type;
-var User = thinky.createModel("User", {
-    id: type.string(),
-    contact: {
-        email: type.string(),
-        phone: type.string()
-    },
-    age: type.number()
-});
-```
-
-One more is with:
-
-```js
-var type = thinky.type;
 var User = thinky.createModel("User", {
     id: type.string(),
     contact: type.object().schema({
@@ -193,9 +165,6 @@ var User = thinky.createModel("User", {
     age: type.number()
 });
 ```
-
-
-
 
 _Example_: Create a model where the field `scores` is an array of `Number`.
 
@@ -210,25 +179,12 @@ var Game = thinky.createModel("Game", {
 Another way to do it is with:
 
 ```js
-var type = thinky.type;
 var Game = thinky.createModel("Game", {
     id: type.string(),
     name: type.string(),
     scores: type.array().schema(type.number())
 });
 ```
-
-One more is with:
-
-```js
-var Game = thinky.createModel("Game", {
-    id: type.string(),
-    name: type.string(),
-    scores: [type.number()]
-});
-```
-
-
 
 _Example_: Create a model where the field `game` is an array of objects with two fields &mdash; `score` and `winner`.
 
@@ -255,9 +211,6 @@ var Game = thinky.createModel("Game", {
     }))
 });
 ```
-
-
-
 
 _Example_: Create a model for a post where the default value for `createdAt` is the
 current date if not specified.


### PR DESCRIPTION
Updated the documentation for Schemas as I saw that there were inconsistencies and duplicate code examples

It appears that declaring 
```
var type = thinky.type;
```
is covered in the quickstart and can possibly be removed here instead of having variations that include it while others that do not.