### PR TITLE
rename event `delete` to `deleted` in documentation

### DIFF
--- a/documentation/api/model.md
+++ b/documentation/api/model.md
@@ -788,7 +788,7 @@ The events that can be emited on a document are:
 
 - `"saving"`: just before a document is saved
 - `"saved"`: once a document is saved
-- `"delete"`: once a document is deleted
+- `"deleted"`: once a document is deleted
 
 
 _Example_: Log every post that we save in the database.


### PR DESCRIPTION
Took me a while to figure this out.

[Referencing test](https://github.com/isaackwan/thinky/blob/master/test/event.js#L66)

Isaac