### PR TITLE
New option in enforce_extra to just log extra fields

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -377,7 +377,7 @@ Model.prototype._createIndex = function(name, fn, opts) {
  * options can be:
  * - init: Boolean (create an index or not)
  * - timeFormat: 'raw'/'native'
- * - enforce_extra: 'strict'/'remove'/'none'
+ * - enforce_extra: 'strict'/'remove'/'log'/'none'
  * - enforce_missing: Boolean
  * - enforce_type: 'strict'/'loose'/'none'
  * - validate: 'oncreate'/'onsave'

--- a/lib/thinky.js
+++ b/lib/thinky.js
@@ -15,7 +15,7 @@ var Errors = require(__dirname+'/errors.js');
  *  - `timeoutError` {number} The wait time before reconnecting in case of an error (in ms), default 1000
  *  - `timeoutGb` {number} How long the pool keep a connection that hasn't been used (in ms), default 60*60*1000
  *  - `enforce_missing` {boolean}, default `false`
- *  - `enforce_extra` {"strict"|"remove"|"none"}, default `"none"`
+ *  - `enforce_extra` {"strict"|"remove"|"log"|"none"}, default `"none"`
  *  - `enforce_type` {"strict"|"loose"|"none"}, default `"loose"`
  *  - `timeFormat` {"raw"|"native"}
  *  - `createDatabase` {boolean} Whether thinky should create the database or not.
@@ -111,7 +111,7 @@ Thinky.prototype.getOptions = function() {
  *  other use cases.
  *  - `timeFormat` {"raw"|"native"} Format of ReQL dates.
  *  - `enforce_missing` {boolean}, default `false`.
- *  - `enforce_extra` {"strict"|"remove"|"none"}, default `"none"`.
+ *  - `enforce_extra` {"strict"|"remove"|"log"|"none"}, default `"none"`.
  *  - `enforce_type` {"strict"|"loose"|"none"}, default `"loose"`.
  *  - `validate` {"oncreate"|"onsave"}, default "onsave".
  */

--- a/lib/type/object.js
+++ b/lib/type/object.js
@@ -154,6 +154,14 @@ TypeObject.prototype.validate = function(object, prefix, options) {
         }
       });
     }
+    else if (localOptions.enforce_extra === "log") {
+      util.loopKeys(object, function(object, key) {
+        if ((self._model === undefined || self._model._joins.hasOwnProperty(key) === false)
+            && (self._schema[key] === undefined)) {
+          util.logExtraField(prefix, key);
+        }
+      });
+    }
   }
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -283,6 +283,15 @@ function extraField(prefix, key) {
 }
 util.extraField = extraField;
 
+function logExtraField(prefix, key) {
+  if (prefix === '') {
+    console.log("Extra field `"+key+"` not allowed.");
+    return;
+  }
+  console.log("Extra field `"+key+"` in "+prefix+" not allowed.")
+}
+util.logExtraField = logExtraField;
+
 
 function looseType(prefix, expected) {
   if ((expected.length > 0) && (vowels[expected[0]])) {

--- a/test/schema.js
+++ b/test/schema.js
@@ -207,6 +207,7 @@ describe('Chainable types', function(){
       return (error instanceof Errors.ValidationError) && (error.message === "Value for [id] must be a string.")
     });
   });
+
   it('String - basic - null and strict', function(){
     var name = util.s8();
     var Model = thinky.createModel(name,
@@ -3085,6 +3086,30 @@ describe('validate', function(){
 
     assert.deepEqual(doc, {id: value.id, otherDoc: {id: otherDoc.id, otherId: otherDoc.otherId}});
 
+  });
+
+  it('Extra field - enforce_extra:"log" - global option', function(){
+    var name = util.s8();
+    var str = util.s8();
+
+    var Model = thinky.createModel(name, {
+      id: String,
+      foo: {fizz: String},
+    }, {init: false, enforce_extra: 'log'})
+
+    doc = new Model({
+      id: str,
+      foo: {fizz: "Hello", buzz: "OMIT"},
+      bar: "OMIT"
+    })
+    doc.validate();
+
+    assert.equal(true, doc.foo.hasOwnProperty('buzz'));
+    assert.deepEqual(doc, {
+      id: str,
+      foo: { fizz: 'Hello', buzz: "OMIT" },
+      bar: "OMIT"
+    });
   });
 
   it('Test option validate="oncreate"', function(){


### PR DESCRIPTION
When trying to set the enforce_extra strict to existing applications, I have found extremely useful to be able to log which extra fields are being passed to save without actually throwing an error. 
This allows to have a more forgiving policy until all possible extra fields have been identified, without the need of going through every single possible missing field.