### PR TITLE
fix(security): updating vulnerable validator package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies":{
     "rethinkdbdash": "~2.3.0",
     "bluebird": "~2.10.2",
-    "validator": "~3.22.1"
+    "validator": "~3.34.0"
   },
   "devDependencies": {
     "mocha": "~1.21.5"


### PR DESCRIPTION
The validator package has an XSS vulnerability, we're using a very old version.
Instead of making it a possible breaking change for the current version (8.x) I updated to the nearest version where the security vulnerability has been fxied: 3.34.0

You can read more here: https://snyk.io/vuln/npm:validator:20150313
Since this is a security update a quick response would be appreciated.